### PR TITLE
allows for key_locations in cluster configs to be HOME dirs

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os
+import os, os.path
 import re
 import time
 import zlib
@@ -41,7 +41,7 @@ class ClusterManager(managers.Manager):
             cl.load_receipt(load_plugins=load_plugins)
             try:
                 key_location = self.cfg.get_key(cl.keyname).get('key_location')
-                cl.key_location = key_location
+                cl.key_location = key_location and os.path.expanduser(key_location)
             except (exception.KeyNotFound, Exception):
                 pass
             return cl
@@ -299,7 +299,7 @@ class Cluster(object):
         self.node_instance_types = node_instance_types
         self.availability_zone = availability_zone
         self.keyname = keyname
-        self.key_location = key_location
+        self.key_location = (key_location and os.path.expanduser(key_location))
         self.volumes = self.load_volumes(volumes)
         self.plugins = self.load_plugins(plugins)
         self.permissions = permissions

--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os
+import os, os.path
 import urllib
 import ConfigParser
 
@@ -295,7 +295,7 @@ class StarClusterConfig(object):
             raise exception.ConfigError(
                 "keypair '%s' not defined in config" % keyname)
         cluster_section['keyname'] = keyname
-        cluster_section['key_location'] = keypair.get('key_location')
+        cluster_section['key_location'] = keypair.get('key_location') and os.path.expanduser(keypair.get('key_location'))
 
     def _load_volumes(self, store):
         cluster_section = store

--- a/starcluster/tests/templates/config.py
+++ b/starcluster/tests/templates/config.py
@@ -6,7 +6,7 @@ default_config = {
     'aws_access_key_id': 'asd0asd9f0asd0fas0d9f0',
     'aws_secret_access_key': 'asdf0a9sdf09203fj0asdf',
     'aws_user_id': 9009230923,
-    'k1_location': '/path/to/k1_rsa',
+    'k1_location': '~/.path/to/k1_rsa',
     'k2_location': '/path/to/k2_rsa',
     'k3_location': '/path/to/k3_rsa',
     'v1_id': 'vol-c999999',

--- a/starcluster/tests/test_config.py
+++ b/starcluster/tests/test_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os
+import os, os.path
 import copy
 import tempfile
 
@@ -113,6 +113,10 @@ class TestStarClusterConfig(tests.StarClusterTest):
         assert 'c2' in self.config.clusters
         assert 'c3' in self.config.clusters
 
+    def test_cluster_key_location_expanded(self):
+        c1 = self.config.clusters.get('c1')
+        assert c1['key_location'] == os.path.expanduser('~/.path/to/k1_rsa')
+
     def test_extends(self):
         c1 = self.config.clusters.get('c1')
         c2 = self.config.clusters.get('c2')
@@ -190,7 +194,7 @@ class TestStarClusterConfig(tests.StarClusterTest):
         k1 = kpairs.get('k1')
         k2 = kpairs.get('k2')
         k3 = kpairs.get('k3')
-        assert k1 and k1['key_location'] == '/path/to/k1_rsa'
+        assert k1 and k1['key_location'] == '~/.path/to/k1_rsa'
         assert k2 and k2['key_location'] == '/path/to/k2_rsa'
         assert k3 and k3['key_location'] == '/path/to/k3_rsa'
 


### PR DESCRIPTION
Hi,
We share our starcluster config among several machines.  Each machine has the needed key paris in the `~/.ec2` dir.  To allow us to share our config I patched the config reader to expand home dir paths.  Do you see any issues with my patch?  (I don't have a lot of python experience so if I haven't done something idomatically pelase let me know as well.)

-Ben
