### PR TITLE
support IPython 0.11 in shell

### DIFF
--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -217,8 +217,8 @@ def iso_to_localtime_tuple(iso):
 try:
     import IPython
     if IPython.__version__ < '0.11':
-        from IPython.Shell import Embed
-        ipy_shell = Embed(argv=[])
+        from IPython.Shell import IPShellEmbed
+        ipy_shell = IPShellEmbed(argv=[])
     else:
         from IPython import embed
         ipy_shell = lambda local_ns=None: embed(user_ns=local_ns)

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -215,8 +215,13 @@ def iso_to_localtime_tuple(iso):
     return datetime.fromtimestamp(t)
 
 try:
-    import IPython.Shell
-    ipy_shell = IPython.Shell.IPShellEmbed(argv=[])
+    import IPython
+    if IPython.__version__ < '0.11':
+        from IPython.Shell import Embed
+        ipy_shell = Embed(argv=[])
+    else:
+        from IPython import embed
+        ipy_shell = lambda local_ns=None: embed(user_ns=local_ns)
 except ImportError:
 
     def ipy_shell(local_ns=None):


### PR DESCRIPTION
This commit adds support for the IPython.embed API, new in IPython 0.11 (soon to be released).
