### PR TITLE
adding the ability to define a local_output_dir so one can use hadoop cl...

### DIFF
--- a/docs/sphinx/plugins/hadoop.rst
+++ b/docs/sphinx/plugins/hadoop.rst
@@ -34,6 +34,25 @@ To use this plugin add a plugin section to your starcluster config file:
     [plugin hadoop]
     setup_class = starcluster.plugins.hadoop.Hadoop
 
+You can optionally specify a local output directory. The plugin will output the
+following config files to that directory
+    - core-site.xml
+    - hdfs-site.xml
+    - mapred-site.xml
+
+.. code-block:: ini
+
+    [plugin hadoop]
+    setup_class = starcluster.plugins.hadoop.Hadoop
+    local_output_dir=/tmp/hadoop/
+
+This is handy as it allows to run hadoop jobs from your local workstation.
+
+.. code-block:: ini
+    export HADOOP_CONF_DIR=/tmp/hadoop
+
+Please make sure that your client and cluster hadoop versions are identical
+
 Next update the ``PLUGINS`` setting of one or more of your cluster templates to
 include the hadoop plugin:
 


### PR DESCRIPTION
simple change : ability to output sc hadoop config files to local_output_dir. 
user can define local_output_dir in the plugin
export HADOOP_CONF_DIR=local_output_dir
and run hadoop jobs from local machine as long as he runs the same client as sc.
