### PR TITLE
speed up node cleanup for big clusters

### DIFF
--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -1,6 +1,7 @@
 """
 clustersetup.py
 """
+import os
 import posixpath
 
 from starcluster import threadpool
@@ -376,8 +377,9 @@ class DefaultClusterSetup(ClusterSetup):
         master.remove_from_known_hosts('root', [node])
         master.remove_from_known_hosts(self._user, [node])
 
+        user_homedir = os.path.expanduser('~' + self._user)
         targets = [posixpath.join('/root', '.ssh','known_hosts'),
-                   posixpath.join(self._user.pw_dir, '.ssh','known_hosts'),]
+                   posixpath.join(user_homedir, '.ssh','known_hosts'),]
 
         for target in targets:
             master.copy_remote_file_to_nodes(target, nodes)

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -353,17 +353,34 @@ class DefaultClusterSetup(ClusterSetup):
 
     def _remove_from_etc_hosts(self, node):
         nodes = filter(lambda x: x.id != node.id, self.running_nodes)
+        master = None
+
         for n in nodes:
-            n.remove_from_etc_hosts([node])
+            if n.is_master():
+                master = n
+
+        master.remove_from_etc_hosts([node])
+        master.master.copy_remote_file_to_nodes('/etc/hosts', nodes)
 
     def _remove_nfs_exports(self, node):
         self._master.stop_exporting_fs_to_nodes([node])
 
     def _remove_from_known_hosts(self, node):
         nodes = filter(lambda x: x.id != node.id, self.running_nodes)
+        master = None
+
         for n in nodes:
-            n.remove_from_known_hosts('root', [node])
-            n.remove_from_known_hosts(self._user, [node])
+            if n.is_master():
+                master = n
+
+        master.remove_from_known_hosts('root', [node])
+        master.remove_from_known_hosts(self._user, [node])
+
+        targets = [posixpath.join('/root', '.ssh','known_hosts'),
+                   posixpath.join(self._user.pw_dir, '.ssh','known_hosts'),]
+
+        for target in targets:
+            master.copy_remote_file_to_nodes(target, nodes)
 
     def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
         self._nodes = nodes

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -361,7 +361,7 @@ class DefaultClusterSetup(ClusterSetup):
                 master = n
 
         master.remove_from_etc_hosts([node])
-        master.master.copy_remote_file_to_nodes('/etc/hosts', nodes)
+        master.copy_remote_file_to_nodes('/etc/hosts', nodes)
 
     def _remove_nfs_exports(self, node):
         self._master.stop_exporting_fs_to_nodes([node])


### PR DESCRIPTION
When working with cluster sizes > 200 nodes, the known_hosts and /etc/hosts cleanup is extremely slow. I'm currently working with a cluster of 400 nodes, and removing a single node takes almost 45mns when starcluster is run from a m1.large instance. 

With this change, the remove node takes 4mns on my 400 node cluster, with the same end results. 
