### PR TITLE
Support for ignoring inline comments in config file

### DIFF
--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -192,7 +192,7 @@ class StarClusterConfig(object):
         """
         cfg = self._get_cfg_fp()
         try:
-            cp = ConfigParser.ConfigParser()
+            cp = InlineCommentsIgnoredConfigParser()
             cp.readfp(cfg)
             self._config = cp
             try:
@@ -214,7 +214,7 @@ class StarClusterConfig(object):
                         raise exception.ConfigError("include %s not found" %
                                                     include)
                 mashup.seek(0)
-                cp = ConfigParser.ConfigParser()
+                cp = InlineCommentsIgnoredConfigParser()
                 cp.readfp(mashup)
                 self._config = cp
             except exception.ConfigSectionMissing:
@@ -679,6 +679,58 @@ class StarClusterConfig(object):
     def get_cluster_manager(self):
         ec2 = self.get_easy_ec2()
         return cluster.ClusterManager(self, ec2)
+
+
+class InlineCommentsIgnoredConfigParser(ConfigParser.ConfigParser):
+    """
+    Class for custom config file parsing that ignores inline comments.
+
+    By default, ConfigParser.ConfigParser only ignores inline comments denoted
+    by a semicolon. This class extends this support to allow inline comments
+    denoted by '#' as well. Just as with semicolons, a spacing character must
+    precede the pound sign for it to be considered an inline comment.
+
+    For example, the following line would have the inline comment ignored:
+
+        FOO = bar # some comment...
+
+    And would be parsed as:
+
+        FOO = bar
+
+    The following would NOT have the comment removed:
+
+        FOO = bar# some comment...
+    """
+
+    def readfp(self, fp, filename=None):
+        """
+        Overrides ConfigParser.ConfigParser.readfp() to ignore inline comments.
+        """
+        if filename is None:
+            try:
+                filename = fp.name
+            except AttributeError:
+                filename = '<???>'
+
+        # We don't use the file iterator here because ConfigParser.readfp()
+        # guarantees to only call readline() on fp, so we want to adhere to
+        # this as well.
+        commentless_fp = StringIO.StringIO()
+        line = fp.readline()
+        while line:
+            pound_pos = line.find('#')
+
+            # A pound sign only starts an inline comment if it is preceded by
+            # whitespace.
+            if pound_pos > 0 and line[pound_pos - 1].isspace():
+                line = line[:pound_pos].rstrip() + '\n'
+            commentless_fp.write(line)
+            line = fp.readline()
+        commentless_fp.seek(0)
+
+        # Cannot use super() because ConfigParser is not a new-style class.
+        ConfigParser.ConfigParser.readfp(self, commentless_fp, filename)
 
 
 if __name__ == "__main__":

--- a/starcluster/tests/test_config.py
+++ b/starcluster/tests/test_config.py
@@ -297,3 +297,22 @@ class TestStarClusterConfig(tests.StarClusterTest):
             except exception.ConfigError:
                 raise Exception(('config rejects valid multiple instance ' +
                                  'type syntax: %s') % case)
+
+    def test_inline_comments(self):
+        """
+        Test that config ignores inline comments.
+        """
+        invalid_case = {'c1_node_type': 'c1.xlarge:3, m1.small# some comment'}
+        try:
+            self.get_custom_config(**invalid_case)
+        except exception.ConfigError:
+            pass
+        else:
+            raise Exception(('config incorrectly ignores line with non-inline '
+                             'comment pound sign: %s') % invalid_case)
+        valid_case = {'c1_node_type': 'c1.xlarge:3, m1.small # some #comment '}
+        try:
+            self.get_custom_config(**valid_case)
+        except exception.ConfigError:
+            raise Exception(('config does not ignore inline '
+                             'comment: %s') % valid_case)


### PR DESCRIPTION
Added custom config parser that ignores inline comments started with a pound sign. This pull request should fix issue #149.
