### PR TITLE
command-line tool multiput

### DIFF
--- a/docs/sphinx/manual/putget.rst
+++ b/docs/sphinx/manual/putget.rst
@@ -23,6 +23,11 @@ To copy files to a different cluster node, use the ``--node`` (``-n``) option::
 
     $ starcluster put mycluster --node node001 /local/path /remote/path
 
+To copy files to multiple cluster nodes, provide comma separated nodes to the
+``--multi`` (``-m``) option::
+
+    $ starcluster put mycluster --multi master,node001 /local/path /remote/path
+
 *********************************
 Copying Data from a Cluster (get)
 *********************************

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -3,6 +3,17 @@ import os
 from starcluster import exception
 from completers import ClusterCompleter
 
+def list_csv(csv_string):
+    """
+    For parsing comma separated values in --multi e.g. --multi master,node001
+    CommaSeparatedValues -> Nodename Generator
+
+    Removes any empty strings from trailing commas
+    >>> list_csv("master,node001,")
+    ["master", "node001"]
+    """
+    return filter(bool, [name.strip() for name in csv_string.split(',')])
+
 
 class CmdPut(ClusterCompleter):
     """
@@ -24,6 +35,9 @@ class CmdPut(ClusterCompleter):
         # Copy a file or dir to a node (node001 in this example)
         $ starcluster put mycluster --node node001 /local/path /remote/path
 
+        # Copy a file or dir to multiple nodes (master and node001 in this example)
+        $ starcluster put mycluster --multi master,node001 /local/path /remote/path
+
 
     This will copy a file or directory to the remote server
     """
@@ -34,6 +48,16 @@ class CmdPut(ClusterCompleter):
                           help="Transfer files as USER ")
         parser.add_option("-n", "--node", dest="node", default="master",
                           help="Transfer files to NODE (defaults to master)")
+        parser.add_option("-m", "--multi", dest="multi", default=None,
+                          help="Transfer files to multiple NODEs (defaults to master)")
+
+    def put(self, node, rpath, lpaths):
+        if self.opts.user:
+            node.ssh.switch_user(self.opts.user)
+        if len(lpaths) > 1 and not node.ssh.isdir(rpath):
+            msg = "Remote path in %s does not exist: %s" % (node, rpath)
+            raise exception.BaseException(msg)
+        node.ssh.put(lpaths, rpath)
 
     def execute(self, args):
         if len(args) < 3:
@@ -47,10 +71,9 @@ class CmdPut(ClusterCompleter):
                 raise exception.BaseException(
                     "Local file or directory does not exist: %s" % lpath)
         cl = self.cm.get_cluster(ctag)
-        node = cl.get_node_by_alias(self.opts.node)
-        if self.opts.user:
-            node.ssh.switch_user(self.opts.user)
-        if len(lpaths) > 1 and not node.ssh.isdir(rpath):
-            raise exception.BaseException("Remote path does not exist: %s" %
-                                          rpath)
-        node.ssh.put(lpaths, rpath)
+        if self.opts.multi:
+            nodes = [cl.get_node_by_alias(nodename) for nodename in list_csv(self.opts.multi)]
+        else:
+            nodes = [cl.get_node_by_alias(self.opts.node)]
+        for node in nodes:
+            self.put(node, rpath, lpaths)

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -3,6 +3,7 @@ import os
 from starcluster import exception
 from completers import ClusterCompleter
 
+
 def list_csv(csv_string):
     """
     For parsing comma separated values in --multi e.g. --multi master,node001
@@ -35,8 +36,9 @@ class CmdPut(ClusterCompleter):
         # Copy a file or dir to a node (node001 in this example)
         $ starcluster put mycluster --node node001 /local/path /remote/path
 
-        # Copy a file or dir to multiple nodes (master and node001 in this example)
-        $ starcluster put mycluster --multi master,node001 /local/path /remote/path
+        # Copy a file or dir to multiple nodes (master and node001 in this
+        # example)
+        $ starcluster put mycluster -m master,node001 /local/path /remote/path
 
 
     This will copy a file or directory to the remote server
@@ -49,7 +51,8 @@ class CmdPut(ClusterCompleter):
         parser.add_option("-n", "--node", dest="node", default="master",
                           help="Transfer files to NODE (defaults to master)")
         parser.add_option("-m", "--multi", dest="multi", default=None,
-                          help="Transfer files to multiple NODEs (defaults to master)")
+                          help="Transfer files to multiple NODEs (defaults to"
+                          + "master)")
 
     def put(self, node, rpath, lpaths):
         if self.opts.user:
@@ -72,7 +75,8 @@ class CmdPut(ClusterCompleter):
                     "Local file or directory does not exist: %s" % lpath)
         cl = self.cm.get_cluster(ctag)
         if self.opts.multi:
-            nodes = [cl.get_node_by_alias(nodename) for nodename in list_csv(self.opts.multi)]
+            nodes = [cl.get_node_by_alias(nodename) for nodename in
+                     list_csv(self.opts.multi)]
         else:
             nodes = [cl.get_node_by_alias(self.opts.node)]
         for node in nodes:


### PR DESCRIPTION
1) Added put functionality with multiple nodes using the `--multi` or `-m` option.
   I hope to soon implement a put command with an `--all` option that will put
   the file to all active nodes in a cluster.
2) I updated the Sphinx documentation to reflect these changes.
