### PR TITLE
Allow multiple space-separated cidr_ip values in security groups, and support URIs as cidr_ip values

### DIFF
--- a/docs/sphinx/manual/configuration.rst
+++ b/docs/sphinx/manual/configuration.rst
@@ -474,7 +474,23 @@ permission section called ``www`` that opens port 80 to the "world" by setting
 the from_port and to_port both to be 80.  You can restrict the ip addresses
 that the rule applies to by specifying the proper cidr_ip setting. In the above
 example, the ``ftp`` permission specifies that only ``66.249.90.104`` ip
-address can access port 21 on the cluster nodes.
+address can access port 21 on the cluster nodes.  Note that you can specify
+more than one cidr_ip:
+	cidr_ip = 66.249.90.104/32 68.233.44.105/32
+
+Alternatively you can restrict a port range to a single IP using a host name.  For
+example if you wanted to serve http only to requests coming from "mydomain.org" and
+"yourdomain.com":
+
+    [permission www]
+    # open port 80 to mydomain.org only
+    from_port = 80
+    to_port = 80
+    cidr_ip = mydomain.org yourdomain.com
+
+Note that a hostname gets resolved to an IP CIDR (such as 1.2.3.4/32) at start time,
+if the IP address for the DNS record happens to change the security policy will need 
+to be changed manually, or the cluster restarted.
 
 Defining Plugins
 ----------------

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -5,6 +5,7 @@ import time
 import string
 import pprint
 import warnings
+import socket # for DNS resolution
 
 from starcluster import utils
 from starcluster import static
@@ -595,17 +596,32 @@ class Cluster(object):
                 ip_protocol = perm.get('ip_protocol', 'tcp')
                 from_port = perm.get('from_port')
                 to_port = perm.get('to_port')
-                cidr_ip = perm.get('cidr_ip', static.WORLD_CIDRIP)
-                if not self.ec2.has_permission(sg, ip_protocol, from_port,
-                                               to_port, cidr_ip):
-                    log.info("Opening %s port range %s-%s for CIDR %s" %
-                             (ip_protocol, from_port, to_port, cidr_ip))
-                    sg.authorize(ip_protocol, from_port, to_port, cidr_ip)
-                includes_ssh = from_port <= ssh_port <= to_port
-                open_to_world = cidr_ip == static.WORLD_CIDRIP
-                if ip_protocol == 'tcp' and includes_ssh and not open_to_world:
-                    sg.revoke(ip_protocol, ssh_port, ssh_port,
-                              static.WORLD_CIDRIP)
+                # allow lists of cidrs
+                for cidr_ip in perm.get('cidr_ip', static.WORLD_CIDRIP).split() :
+                    # is that actually a DNS name? (and not a security group name?)
+                    if (("." in cidr_ip) and not ("/"in cidr_ip)) :
+                        try :
+                            cidr_dns = socket.gethostbyname(cidr_ip)+"/32"
+                            log.info("The cidr_ip value %s resolves to " % cidr_ip)
+                            log.info("%s. If this is not a static IP address,"% cidr_dns)
+                            log.info("it could eventually change.  If so you will have to manually")
+                            log.info("adjust the IP address in the port %s CIDR setting." % from_port)
+                            cidr_ip = cidr_dns
+                        except :
+                            cidr_dns = cidr_ip
+                            cidr_ip = static.WORLD_CIDRIP
+                            log.emerg("cannot resolve DNS name %s, using %s instead" %
+                                 (cidr_dns, cidr_ip))
+                    if not self.ec2.has_permission(sg, ip_protocol, from_port,
+                                                   to_port, cidr_ip):
+                        log.info("Opening %s port range %s-%s for CIDR %s" %
+                                 (ip_protocol, from_port, to_port, cidr_ip))
+                        sg.authorize(ip_protocol, from_port, to_port, cidr_ip)
+                    includes_ssh = from_port <= ssh_port <= to_port
+                    open_to_world = cidr_ip == static.WORLD_CIDRIP
+                    if ip_protocol == 'tcp' and includes_ssh and not open_to_world:
+                        sg.revoke(ip_protocol, ssh_port, ssh_port,
+                                  static.WORLD_CIDRIP)
             self._cluster_group = sg
         return self._cluster_group
 
@@ -1851,9 +1867,15 @@ class ClusterValidator(validators.Validator):
                 raise exception.InvalidPortRange(
                     from_port, to_port,
                     reason="'from_port' must be <= 'to_port'")
-            cidr_ip = permission.get('cidr_ip')
-            if not iptools.validate_cidr(cidr_ip):
-                raise exception.InvalidCIDRSpecified(cidr_ip)
+            for cidr_ip in permission.get('cidr_ip').split() :
+                if (("." in cidr_ip) and not ("/" in cidr_ip)) :
+                    try:
+                        cidr_dns = socket.gethostbyname(cidr_ip)
+                    except:
+                        raise exception.InvalidCIDRDNSSpecified(cidr_ip)
+                else :
+                    if not iptools.validate_cidr(cidr_ip):
+                        raise exception.InvalidCIDRSpecified(cidr_ip)
 
     def validate_ebs_settings(self):
         """

--- a/starcluster/exception.py
+++ b/starcluster/exception.py
@@ -347,6 +347,11 @@ class InvalidCIDRSpecified(ClusterValidationError):
     def __init__(self, cidr):
         self.msg = "cidr_ip is invalid: %s" % cidr
 
+class InvalidCIDRDNSSpecified(ClusterValidationError):
+    """Raised when user specifies an invalid CIDR dns name for permission"""
+    def __init__(self, cidr):
+        self.msg = "cidr_ip appears to be a DNS reference but cannot be resolved: %s" % cidr
+
 
 class InvalidZone(ClusterValidationError):
     """


### PR DESCRIPTION
This is work I did earlier in an untidy branch (still getting used to Git).  Hopefully this is easier to pull from.
