### PR TITLE
Fixed ebsimage bug

### DIFF
--- a/starcluster/image.py
+++ b/starcluster/image.py
@@ -237,7 +237,8 @@ class EBSImageCreator(ImageCreator):
                 time.sleep(5)
         finally:
             s.stop()
-        snap = img.block_device_mapping['/dev/sda1'].snapshot_id
+        snapshot_id = img.block_device_mapping['/dev/sda1'].snapshot_id
+        snap = self.ec2.conn.get_all_snapshots(snapshot_ids=[snapshot_id])[0]
         self.ec2.wait_for_snapshot(snap)
         log.info("Waiting for %s to become available..." % imgid,
                  extra=dict(__nonewline__=True))


### PR DESCRIPTION
A snapshot id was being passed when a snapshot object was expected.

Caused this error:

earls3@jearls:~$ starcluster ebsimage i-14b2086a delete-me-10
StarCluster - (http://star.mit.edu/cluster) (v. 0.9999)
Software Tools for Academics and Researchers (STAR)
Please submit bug reports to starcluster@mit.edu

> > > Removing private data...
> > > Creating new EBS AMI...
> > > New EBS AMI created: ami-8345c7ea
> > > Fetching block device mapping for ami-8345c7ea
> > > !!! ERROR - Error occurred while creating image
> > > !!! ERROR - Unhandled exception occured
> > > Traceback (most recent call last):
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/cli.py", line 257, in main
> > >     sc.execute(args)
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/commands/ebsimage.py", line 61, in execute
> > >     *_self.specified_options_dict)
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/awsutils.py", line 773, in create_ebs_image
> > >     return icreator.create_image(size=root_vol_size)
> > >   File "<string>", line 2, in create_image
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/utils.py", line 91, in wrap_f
> > >     res = func(_arg, **kargs)
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/image.py", line 211, in create_image
> > >     return self._create_image_from_ebs(size)
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/image.py", line 241, in _create_image_from_ebs
> > >     self.ec2.wait_for_snapshot(snap)
> > >   File "/usr/local/lib/python2.6/dist-packages/StarCluster-0.9999-py2.6.egg/starcluster/awsutils.py", line 1032, in wait_for_snapshot
> > >     log.info("Waiting for snapshot to complete: %s" % snap.id)
> > > AttributeError: 'unicode' object has no attribute 'id'

!!! ERROR - Oops! Looks like you've found a bug in StarCluster
!!! ERROR - Crash report written to: /home/earls3/.starcluster/logs/crash-report-14437.txt
!!! ERROR - Please remove any sensitive data from the crash report
!!! ERROR - and submit it to starcluster@mit.edu
