### PR TITLE
Added m3 instances as valid HVM instances

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1726,8 +1726,11 @@ class ClusterValidator(validators.Validator):
         image_is_hvm = (image.virtualization_type == "hvm")
         instance_is_hvm = instance_type in static.CLUSTER_TYPES
         instance_is_hi_io = instance_type in static.HI_IO_TYPES
-        if image_is_hvm and not instance_is_hvm and not instance_is_hi_io:
-            cctypes_list = ', '.join(static.CLUSTER_TYPES + static.HI_IO_TYPES)
+        instance_is_sec_gen = instance_type in static.SEC_GEN_TYPES
+        if (image_is_hvm and not instance_is_hvm and not 
+            instance_is_hi_io and not instance_is_sec_gen):
+            cctypes_list = ', '.join(static.SEC_GEN_TYPES + static.CLUSTER_TYPES +
+                                     static.HI_IO_TYPES)
             raise exception.ClusterValidationError(
                 "Image '%s' is a hardware virtual machine (HVM) image and "
                 "cannot be used with instance type '%s'.\n\nHVM images "

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -103,6 +103,8 @@ INSTANCE_TYPES = {
 
 MICRO_INSTANCE_TYPES = ['t1.micro']
 
+SEC_GEN_TYPES = ['m3.xlarge', 'm3.2xlarge']
+
 CLUSTER_COMPUTE_TYPES = ['cc1.4xlarge', 'cc2.8xlarge']
 
 CLUSTER_GPU_TYPES = ['cg1.4xlarge']


### PR DESCRIPTION
This fixes issue #169, m3 instances were not being checked on '_check_platform' as valid HVM instance types, a second generation instances list was added to the static.py file and updated the validation in cluster.py
