### PR TITLE
Fixes 2 issues related to loading plugins

### DIFF
--- a/starcluster/deathrow.py
+++ b/starcluster/deathrow.py
@@ -2,8 +2,6 @@
 Contains code that should eventually be removed. Mostly used for maintaining
 backwards compatibility while still moving the code forward.
 """
-import traceback
-
 from starcluster import utils
 from starcluster import exception
 from starcluster import clustersetup
@@ -68,7 +66,7 @@ def _load_plugins(plugins, debug=True):
         try:
             plug_obj = klass(*config_args, **config_kwargs)
         except Exception as exc:
-            log.debug(traceback.format_exc())
+            log.error("Error occured:", exc_info=True)
             raise exception.PluginLoadError(
                 "Failed to load plugin %s with "
                 "the following error: %s - %s" %

--- a/starcluster/deathrow.py
+++ b/starcluster/deathrow.py
@@ -2,6 +2,8 @@
 Contains code that should eventually be removed. Mostly used for maintaining
 backwards compatibility while still moving the code forward.
 """
+import traceback
+
 from starcluster import utils
 from starcluster import exception
 from starcluster import clustersetup
@@ -63,7 +65,14 @@ def _load_plugins(plugins, debug=True):
                 config_kwargs[arg] = plugin.get(arg)
         if debug:
             log.debug("config_kwargs = %s" % config_kwargs)
-        plug_obj = klass(*config_args, **config_kwargs)
+        try:
+            plug_obj = klass(*config_args, **config_kwargs)
+        except Exception as exc:
+            log.debug(traceback.format_exc())
+            raise exception.PluginLoadError(
+                "Failed to load plugin %s with "
+                "the following error: %s - %s" %
+                (setup_class, exc.__class__.__name__, exc.message))
         if not hasattr(plug_obj, '__name__'):
             setattr(plug_obj, '__name__', plugin_name)
         plugs.append(plug_obj)

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -156,7 +156,7 @@ class Node(object):
             try:
                 plug = getattr(mod, klass_name)(*args, **kwargs)
             except Exception as exc:
-                raise exception.exception.PluginLoadError(exc.message)
+                raise exception.PluginLoadError(exc.message)
             plugs.append(plug)
         return plugs
 

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -4,7 +4,6 @@ import stat
 import base64
 import posixpath
 import subprocess
-import traceback
 
 from starcluster import utils
 from starcluster import static
@@ -146,6 +145,7 @@ class Node(object):
             mod_path, klass_name = klass.rsplit('.', 1)
             try:
                 mod = __import__(mod_path, fromlist=[klass_name])
+                plug = getattr(mod, klass_name)(*args, **kwargs)
             except SyntaxError, e:
                 raise exception.PluginSyntaxError(
                     "Plugin %s (%s) contains a syntax error at line %s" %
@@ -154,10 +154,8 @@ class Node(object):
                 raise exception.PluginLoadError(
                     "Failed to import plugin %s: %s" %
                     (klass_name, e[0]))
-            try:
-                plug = getattr(mod, klass_name)(*args, **kwargs)
             except Exception as exc:
-                log.debug(traceback.format_exc())
+                log.error("Error occured:", exc_info=True)
                 raise exception.PluginLoadError(
                     "Failed to load plugin %s with "
                     "the following error: %s - %s" %

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -4,6 +4,7 @@ import stat
 import base64
 import posixpath
 import subprocess
+import traceback
 
 from starcluster import utils
 from starcluster import static
@@ -156,6 +157,7 @@ class Node(object):
             try:
                 plug = getattr(mod, klass_name)(*args, **kwargs)
             except Exception as exc:
+                log.debug(traceback.format_exc())
                 raise exception.PluginLoadError(
                     "Failed to load plugin %s with "
                     "the following error: %s - %s" %

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -153,7 +153,10 @@ class Node(object):
                 raise exception.PluginLoadError(
                     "Failed to import plugin %s: %s" %
                     (klass_name, e[0]))
-            plug = getattr(mod, klass_name)(*args, **kwargs)
+            try:
+                plug = getattr(mod, klass_name)(*args, **kwargs)
+            except Exception as exc:
+                raise exception.exception.PluginLoadError(exc.message)
             plugs.append(plug)
         return plugs
 

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -156,7 +156,10 @@ class Node(object):
             try:
                 plug = getattr(mod, klass_name)(*args, **kwargs)
             except Exception as exc:
-                raise exception.PluginLoadError(exc.message)
+                raise exception.PluginLoadError(
+                    "Failed to load plugin %s with "
+                    "the following error: %s - %s" %
+                    (klass_name, exc.__class__.__name__, exc.message))
             plugs.append(plug)
         return plugs
 


### PR DESCRIPTION
1. Fixes an issue where the error message "Incompatible Cluster: mycluster" would be printed when a plugin fails initialization. Now prints "ERROR - An error occurred while loading plugins: {back trace} Failed to load plugin {xyz} with the following error: {err_msg}. This error may occur if the plugin code is modified after the cluster was created.
2. Fixes an issue where the error message "ERROR - cluster template smallcluster does not exist" when trying to launch a cluster with plugins that fail initialization. Now prints an error message similar than the one from point 1.
