### PR TITLE
[MRG]: new version of the ipcluster plugin to drop the SGE requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyo
 *.pkl
 *~
+.DS_Store
 pip-log.txt
 MANIFEST
 build

--- a/docs/sphinx/plugins/ipython.rst
+++ b/docs/sphinx/plugins/ipython.rst
@@ -125,6 +125,56 @@ automatically be started and connected to the controller process running on
 instance will automatically be able to leverage the new computing resources to
 speed-up ongoing computation.
 
+
+***************************
+Configuring a custom packer
+***************************
+
+The default message packer for IPython parellel is based on the JSON format
+which is quite slow but will work out of the box. It is possible to instead
+configure the faster ``'pickle'`` packer::
+
+    [plugin ipcluster]
+    setup_class = starcluster.plugins.ipcluster.IPCluster
+    enable_notebook = True
+    notebook_directory = notebooks
+    # set a password for the notebook for increased security
+    notebook_passwd = a-secret-password
+    packer = pickle
+
+When using IPython 0.13 this will require to pass an additional
+``packer='pickle'``. For instance if running the client directly from the
+master node::
+
+    $ starcluster sshmaster mycluster -u myuser
+    $ ipython
+    [~]> from IPython.parallel import Client
+    [~]> rc = Client(packer='pickle')
+
+If the ``msgpack-python`` package is installed on all the cluster nodes and on
+the client, is is possible to get even faster serialization of the messages
+with::
+
+    [plugin ipcluster]
+    setup_class = starcluster.plugins.ipcluster.IPCluster
+    enable_notebook = True
+    notebook_directory = notebooks
+    # set a password for the notebook for increased security
+    notebook_passwd = a-secret-password
+    packer = msgpack
+
+And then from the client::
+
+    $ starcluster sshmaster mycluster -u myuser
+    $ ipython
+    [~]> from IPython.parallel import Client
+    [~]> rc = Client(packer='msgpack.packb', unpacker='msgpack.unpackb')
+
+**Note**: from IPython 0.14 and on the client will automatically fetch the
+packer configuration from the controller configuration without passing an
+additional constuctor argument to the ``Client`` class.
+
+
 **********************************
 Restarting All the Engines at Once
 **********************************

--- a/docs/sphinx/plugins/ipython.rst
+++ b/docs/sphinx/plugins/ipython.rst
@@ -7,7 +7,7 @@ IPython Cluster Plugin
 .. note::
 
     These docs are for `IPython`_ 0.13+ which is installed in the latest
-    StarCluster 12.10 Ubuntu-based AMIs. See `starcluster listpublic` for
+    StarCluster 12.04 Ubuntu-based AMIs. See `starcluster listpublic` for
     a list of available AMIs.
 
 To configure your cluster as an `interactive IPython cluster`_ you must first
@@ -130,7 +130,7 @@ speed-up ongoing computation.
 Configuring a custom packer
 ***************************
 
-The default message packer for IPython parellel is based on the JSON format
+The default message packer for ``IPython.parallel`` is based on the JSON format
 which is quite slow but will work out of the box. It is possible to instead
 configure the faster ``'pickle'`` packer::
 

--- a/docs/sphinx/plugins/ipython.rst
+++ b/docs/sphinx/plugins/ipython.rst
@@ -118,7 +118,7 @@ case the above config should be updated to::
     rc = Client('/home/user/.starcluster/ipcluster/mycluster-us-east-1.json'
                 sshkey='/home/user/.ssh/mykey.rsa')
 
-Note: it is possible to dynamically add new nodes with the ``startcluster
+Note: it is possible to dynamically add new nodes with the ``starcluster
 addnode`` command to a pre-existing cluster. New IPython engines will
 automatically be started and connected to the controller process running on
 ``master``. This means that existing ``Client`` and ``LoadBalancedView``

--- a/docs/sphinx/plugins/ipython.rst
+++ b/docs/sphinx/plugins/ipython.rst
@@ -118,6 +118,40 @@ case the above config should be updated to::
     rc = Client('/home/user/.starcluster/ipcluster/mycluster-us-east-1.json'
                 sshkey='/home/user/.ssh/mykey.rsa')
 
+Note: it is possible to dynamically add new nodes with the ``startcluster
+addnode`` command to a pre-existing cluster. New IPython engines will
+automatically be started and connected to the controller process running on
+``master``. This means that existing ``Client`` and ``LoadBalancedView``
+instance will automatically be able to leverage the new computing resources to
+speed-up ongoing computation.
+
+**********************************
+Restarting All the Engines at Once
+**********************************
+
+Sometimes some IPython engine processes become unstable (non-interruptable,
+long running computation or memory leaks in compiled extension code for
+instance).
+
+In such a case it is possible to kill all running engine processes and start
+new ones automatically connected to the existing controller by adding a some
+configuration for the the ``IPClusterRestartEngines`` plugin in your
+``.starcluster/config`` file::
+
+    [plugin ipclusterrestart]
+    SETUP_CLASS = starcluster.plugins.ipcluster.IPClusterRestartEngines
+
+You can then trigger the restart manually using::
+
+    $ starcluster runplugin ipclusterrestart iptest
+    StarCluster - (http://star.mit.edu/cluster) (v. 0.9999)
+    Software Tools for Academics and Researchers (STAR)
+    Please submit bug reports to starcluster@mit.edu
+
+    >>> Running plugin ipclusterrestart
+    >>> Restarting 23 engines on 3 nodes
+    3/3 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| 100%
+
 .. _ipython-notebook:
 
 *******************************

--- a/docs/sphinx/plugins/ipython.rst
+++ b/docs/sphinx/plugins/ipython.rst
@@ -30,6 +30,7 @@ also want to add the following settings:
     enable_notebook = True
     # set a password for the notebook for increased security
     notebook_passwd = a-secret-password
+    notebook_directory = notebooks
 
 After defining the plugin in your config, add the ipcluster plugin to the list
 of plugins in one of your cluster templates:

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -363,7 +363,7 @@ class Cluster(object):
                  plugins=[],
                  permissions=[],
                  userdata_scripts=[],
-                 refresh_interval=5,
+                 refresh_interval=30,
                  disable_queue=False,
                  num_threads=20,
                  disable_threads=False,

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -363,7 +363,7 @@ class Cluster(object):
                  plugins=[],
                  permissions=[],
                  userdata_scripts=[],
-                 refresh_interval=30,
+                 refresh_interval=5,
                  disable_queue=False,
                  num_threads=20,
                  disable_threads=False,

--- a/starcluster/commands/shell.py
+++ b/starcluster/commands/shell.py
@@ -120,7 +120,7 @@ class CmdShell(CmdBase):
             key_location = cl.master_node.key_location
             self._add_to_known_hosts(cl.master_node)
             log.info("Loading parallel IPython client and view")
-            rc = Client(local_json, sshkey=key_location, packer='pickle')
+            rc = Client(local_json, sshkey=key_location)
             local_ns['Client'] = Client
             local_ns['ipcluster'] = cl
             local_ns['ipclient'] = rc

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -105,7 +105,7 @@ class Node(object):
                     raise exception.IncompatibleCluster(parent_cluster)
                 else:
                     raise exception.BaseException(
-                        "Error occured unbundling userdata: %s" % e)
+                        "Error occurred unbundling userdata: %s" % e)
         return self._user_data
 
     @property

--- a/starcluster/plugins/ipcluster.py
+++ b/starcluster/plugins/ipcluster.py
@@ -28,6 +28,11 @@ CHANNEL_NAMES = (
 STARTED_MSG = """\
 IPCluster has been started on %(cluster)s for user '%(user)s'.
 
+To connect to cluster from your local machine use:
+
+    >>> from IPython.parallel import Client
+    >>> Client('%(connector_file)s', sshkey='%(key_location)s')
+
 See the IPCluster plugin doc for usage details:
 http://star.mit.edu/cluster/docs/latest/plugins/ipython.html
 """
@@ -142,7 +147,10 @@ class IPCluster(DefaultClusterSetup):
         master.ssh.get(json_filename, local_json)
         connection_params = json.load(open(local_json, 'rb'))
         for channel in CHANNEL_NAMES:
-            self._authorize_port(master, connection_params[channel], channel)
+            port = connection_params.get(channel)
+            if port is not None:
+                self._authorize_port(master, port, channel)
+
         return local_json
 
     def _start_notebook(self, master, user, profile_dir):

--- a/starcluster/plugins/ipcluster.py
+++ b/starcluster/plugins/ipcluster.py
@@ -1,12 +1,11 @@
 """
-A starcluster plugin for running an IPython cluster using SGE
-(requires IPython 0.11+pyzmq or 0.10+twisted)
-
-See ipythondev plugin for installing git master IPython and its dependencies
+A starcluster plugin for running an IPython cluster
+(requires IPython 0.13+)
 """
 import os
 import time
 import posixpath
+from threading import Thread
 
 from starcluster import utils
 from starcluster import static
@@ -18,58 +17,22 @@ from starcluster.logger import log
 
 IPCLUSTER_CACHE = os.path.join(static.STARCLUSTER_CFG_DIR, 'ipcluster')
 
-STARTED_MSG_10 = """\
-IPCluster has been started on %(cluster)s for user '%(user)s'.
 
-See the IPython 0.10.* parallel docs for usage details
-(http://ipython.org/ipython-doc/rel-0.10.2/html/parallel)
-"""
-
-
-class IPCluster10(ClusterSetup):
-    """
-    Starts an IPCluster (0.10.*) on StarCluster
-    """
-    cluster_file = '/etc/clusterfile.py'
-    log_file = '/var/log/ipcluster.log'
-
-    def _create_cluster_file(self, master, nodes):
-        engines = {}
-        for node in nodes:
-            engines[node.alias] = node.num_processors
-        cfile = 'send_furl = True\n'
-        cfile += 'engines = %s\n' % engines
-        f = master.ssh.remote_file(self.cluster_file, 'w')
-        f.write(cfile)
-        f.close()
-
-    def run(self, nodes, master, user, user_shell, volumes):
-        self._create_cluster_file(master, nodes)
-        log.info("Starting ipcluster...")
-        master.ssh.execute(
-            "su - %s -c 'screen -d -m ipcluster ssh --clusterfile %s'" %
-            (user, self.cluster_file))
-        log.info(STARTED_MSG_10 % dict(cluster=master.parent_cluster,
-                                       user=user))
-
-    def on_add_node(self, node, nodes, master, user, user_shell, volumes):
-        log.info("Adding %s to ipcluster" % node.alias)
-        self._create_cluster_file(master, nodes)
-        user_home = node.getpwnam(user).pw_dir
-        furl_file = posixpath.join(user_home, '.ipython', 'security',
-                                   'ipcontroller-engine.furl')
-        node.ssh.execute(
-            "su - %s -c 'screen -d -m ipengine --furl-file %s'" %
-            (user, furl_file))
-
-    def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
-        log.info("Removing %s from ipcluster" % node.alias)
-        less_nodes = filter(lambda x: x.id != node.id, nodes)
-        self._create_cluster_file(master, less_nodes)
-        node.ssh.execute('pkill ipengine')
+def threaded_call(f, all_args, join=True):
+    """Run a function in parallell"""
+    threads = []
+    for args in all_args:
+        t = Thread(target=f, args=args)
+        t.start()
+        threads.append(t)
+    if join:
+        for t in threads:
+            t.join()
+    else:
+        return threads
 
 
-STARTED_MSG_11 = """\
+STARTED_MSG = """\
 IPCluster has been started on %(cluster)s for user '%(user)s'.
 
 See the IPCluster plugin doc for usage details:
@@ -77,19 +40,22 @@ http://star.mit.edu/cluster/docs/latest/plugins/ipython.html
 """
 
 
-class IPCluster11(ClusterSetup):
-    """
-    Start an IPython (>= 0.11) cluster
-    """
+class IPCluster(ClusterSetup):
+    """Start an IPython (>= 0.11) cluster"""
     def __init__(self, enable_notebook=False, notebook_passwd=None):
         self.enable_notebook = enable_notebook
         self.notebook_passwd = notebook_passwd or utils.generate_passwd(16)
 
+    def _check_ipython_installed(self, node):
+        has_ipy = node.ssh.has_required(['ipython', 'ipcluster'])
+        if not has_ipy:
+            log.error("IPython is not installed... skipping plugin")
+        return has_ipy
+
     def _write_config(self, master, user, profile_dir):
-        """
-        Create cluster config
-        """
+        """Create cluster configuration files."""
         log.info("Writing IPython cluster config files")
+        master.ssh.execute("rm -rf '%s'" % profile_dir)
         master.ssh.execute('ipython profile create')
         f = master.ssh.remote_file('%s/ipcontroller_config.py' % profile_dir)
         ssh_server = "@".join([user, master.public_dns_name])
@@ -98,41 +64,6 @@ class IPCluster11(ClusterSetup):
             "c.HubFactory.ip='%s'" % master.private_ip_address,
             "c.IPControllerApp.ssh_server='%s'" % ssh_server,
             # "c.Application.log_level = 'DEBUG'",
-            "",
-        ]))
-        f.close()
-        f = master.ssh.remote_file('%s/ipcluster_config.py' % profile_dir)
-        f.write('\n'.join([
-            "c = get_config()",
-            "c.IPClusterStart.controller_launcher_class=" +
-            "'SGEControllerLauncher'",
-            # restrict controller to master node:
-            "c.SGEControllerLauncher.queue='all.q@master'",
-            "c.IPClusterEngines.engine_launcher_class='SGEEngineSetLauncher'",
-            # "c.Application.log_level = 'DEBUG'",
-            "",
-            # workaround IPython bug #2171 in IPython 0.13
-            "controller_template = '''",
-            "#$ -V",
-            "#$ -q all.q@master",
-            "#$ -S /bin/sh",
-            "#$ -N ipcontroller",
-            'ipcontroller --log-to-file --profile-dir="{profile_dir}" '
-            '--cluster-id="{cluster_id}"',
-            "'''",
-            "engine_template = '''",
-            "#$ -V",
-            "#$ -t 1-{n}",
-            "#$ -S /bin/sh",
-            "#$ -N ipengine",
-            'ipengine --log-to-file --profile-dir="{profile_dir}" '
-            '--cluster-id="{cluster_id}"',
-            "'''",
-            # only apply workaround for affected version 0.13:
-            "import IPython",
-            "if IPython.__version__ == '0.13':",
-            "    c.SGEControllerLauncher.batch_template = controller_template",
-            "    c.SGEEngineSetLauncher.batch_template = engine_template",
             "",
         ]))
         f.close()
@@ -161,18 +92,21 @@ class IPCluster11(ClusterSetup):
             "    c.Session.unpacker='msgpack.unpackb'",
             "c.EngineFactory.timeout = 10",
             # Engines should wait a while for url files to arrive,
-            # in case Controller takes a bit to start via SGE
+            # in case Controller takes a bit to start
             "c.IPEngineApp.wait_for_url_file = 30",
             # "c.Application.log_level = 'DEBUG'",
             "",
         ]))
         f.close()
 
-    def _start_cluster(self, master, n, profile_dir):
-        log.info("Starting IPython cluster with %i engines" % n)
+    def _start_cluster(self, master, profile_dir):
+        n_engines = max(1, master.num_processors - 1)
+        log.info("Starting IPython cluster with %i engines on master"
+                 % n_engines)
         # cleanup existing connection files, to prevent their use
         master.ssh.execute("rm -f %s/security/*.json" % profile_dir)
-        master.ssh.execute("ipcluster start --n=%i --delay=5 --daemonize" % n)
+        master.ssh.execute("ipcluster start --n=%i --delay=5 --daemonize"
+                           % n_engines)
         # wait for JSON file to exist
         json = '%s/security/ipcontroller-client.json' % profile_dir
         log.info("Waiting for JSON connector file...",
@@ -181,7 +115,7 @@ class IPCluster11(ClusterSetup):
         s.start()
         try:
             while not master.ssh.isfile(json):
-                time.sleep(5)
+                time.sleep(1)
         finally:
             s.stop()
         # retrieve JSON connection info
@@ -244,15 +178,25 @@ class IPCluster11(ClusterSetup):
 
     @print_timing("IPCluster")
     def run(self, nodes, master, user, user_shell, volumes):
-        n = sum([node.num_processors for node in nodes]) - 1
-        user_home = node.getpwnam(user).pw_dir
+        if not self._check_ipython_installed(master):
+            return
+        user_home = master.getpwnam(user).pw_dir
         profile_dir = posixpath.join(user_home, '.ipython', 'profile_default')
         master.ssh.switch_user(user)
         self._write_config(master, user, profile_dir)
-        cfile = self._start_cluster(master, n, profile_dir)
+
+        # Start the cluster and some engines on the master (leave 1
+        # processor free to handle cluster house keeping)
+        cfile = self._start_cluster(master, profile_dir)
+
+        # Start engines on each of the non-master nodes
+        start_engine_args = [(node, user) for node in nodes
+                             if not node.is_master()]
+        threaded_call(self._start_engines, start_engine_args)
+
         if self.enable_notebook:
             self._start_notebook(master, user, profile_dir)
-        log.info(STARTED_MSG_11 % dict(cluster=master.parent_cluster,
+        log.info(STARTED_MSG % dict(cluster=master.parent_cluster,
                                        user=user, connector_file=cfile,
                                        key_location=master.key_location))
         master.ssh.switch_user('root')
@@ -262,53 +206,23 @@ class IPCluster11(ClusterSetup):
         master.ssh.execute("pkill -f ipcontrollerapp.py")
 
     def on_add_node(self, node, nodes, master, user, user_shell, volumes):
-        n = node.num_processors
-        log.info("Adding %i engines on %s to ipcluster" % (n, node.alias))
-        node.ssh.execute("ipcluster engines --n=%i --daemonize" % n)
-
-
-class IPCluster(ClusterSetup):
-
-    def __init__(self, enable_notebook=False, notebook_passwd=None):
-        self.enable_notebook = enable_notebook
-        self.notebook_passwd = notebook_passwd
-
-    def _get_ipy_version(self, node):
-        version_cmd = "python -c 'import IPython; print IPython.__version__'"
-        return node.ssh.execute(version_cmd)[0]
-
-    def _get_ipcluster_plugin(self, node):
-        ipyversion = self._get_ipy_version(node)
-        if ipyversion < '0.11':
-            if not ipyversion.startswith('0.10'):
-                log.warn("Trying unsupported IPython version %s" % ipyversion)
-            return IPCluster10()
-        else:
-            return IPCluster11(self.enable_notebook, self.notebook_passwd)
-
-    def _check_ipython_installed(self, node):
-        has_ipy = node.ssh.has_required(['ipython', 'ipcluster'])
-        if not has_ipy:
-            log.error("IPython is not installed...skipping plugin")
-        return has_ipy
-
-    def run(self, nodes, master, user, user_shell, volumes):
-        if not self._check_ipython_installed(master):
-            return
-        plug = self._get_ipcluster_plugin(master)
-        plug.run(nodes, master, user, user_shell, volumes)
-
-    def on_add_node(self, node, nodes, master, user, user_shell, volumes):
-        if not self._check_ipython_installed(master):
-            return
-        plug = self._get_ipcluster_plugin(master)
-        plug.on_add_node(node, nodes, master, user, user_shell, volumes)
+       if not self._check_ipython_installed(master):
+           return
+       self._start_engines(node, user)
 
     def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
         if not self._check_ipython_installed(master):
             return
-        plug = self._get_ipcluster_plugin(master)
-        plug.on_remove_node(node, nodes, master, user, user_shell, volumes)
+        # TODO: is there a better way?
+        log.info("Removing %s from ipcluster" % node.alias)
+        node.ssh.execute('pkill -f ipengineapp.py')
+
+    def _start_engines(self, node, user):
+        n = node.num_processors
+        log.info("Adding %i engines on %s to ipcluster" % (n, node.alias))
+        node.ssh.switch_user(user)
+        node.ssh.execute("ipcluster engines --n=%i --daemonize" % n)
+        node.ssh.switch_user('root')
 
 
 class IPClusterStop(ClusterSetup):

--- a/starcluster/plugins/ipcluster.py
+++ b/starcluster/plugins/ipcluster.py
@@ -285,7 +285,7 @@ class IPCluster(DefaultClusterSetup):
 class IPClusterStop(DefaultClusterSetup):
     """Shutdown all the IPython processes of the cluster
 
-    This plugin is meant to be run manuall with:
+    This plugin is meant to be run manually with:
 
       starcluster runplugin plugin_conf_name cluster_name
 
@@ -318,7 +318,11 @@ class IPClusterStop(DefaultClusterSetup):
 class IPClusterRestartEngines(DefaultClusterSetup):
     """Plugin to kill and restart all engines of an IPython cluster
 
-    This plugin is meant to be run manuall with:
+    This plugin can be useful to hard-reset the all the engines, for instance
+    to be sure to free all the used memory even when dealing with memory leaks
+    in compiled extensions.
+
+    This plugin is meant to be run manually with:
 
       starcluster runplugin plugin_conf_name cluster_name
 

--- a/starcluster/plugins/ipcluster.py
+++ b/starcluster/plugins/ipcluster.py
@@ -26,14 +26,13 @@ CHANNEL_NAMES = (
 )
 
 STARTED_MSG = """\
-IPCluster has been started on %(cluster)s for user '%(user)s'.
+IPCluster has been started on %(cluster)s for user '%(user)s'
+with %(n_engines)d engines on %(n_nodes)d nodes.
 
 To connect to cluster from your local machine use:
 
-  >>> from IPython.parallel import Client
-  >>> client = Client('%(connector_file)s', sshkey='%(key_location)s')
-
-Started %(n_engines)d active engines on %(n_nodes)d.
+from IPython.parallel import Client
+client = Client('%(connector_file)s', sshkey='%(key_location)s')
 
 See the IPCluster plugin doc for usage details:
 http://star.mit.edu/cluster/docs/latest/plugins/ipython.html


### PR DESCRIPTION
The NFS partition is used instead to be able to run:

```
ipcluster engines -n numproc
```

on each non-master node of the cluster.

TODO:
- <del>update the documentation</del>
- <del>find out why running the notebook locally using the fetched json definition does not work (security group configuration issue?)</del> configured the SG to open the controller ports
- review the configuration: would it be better to leave the default configuration instead?
- <del>change the packer config to selection between json (default), pickle or msgpack + documentation.</del>

This is an early pull request to collect feedback from others, especially @minrk before moving further with the documentation update.

Also some questions for Min:
- <del>would it be possible to restart all the engines of the cluster from the controller? Would this require to configure the ssh mode [1] instead? If so, where is the API to shutdown and restart all the active engines?</del> Basic restart plugin implemented, better version will require some refactoring upstream in IPython
- <del>is there a cleaner way to shutdown some engines (with a timeout before calling the `pkill` command) in the `on_remove_node` method?</del> Good enough for now.

[1] http://ipython.org/ipython-doc/dev/parallel/parallel_process.html#using-ipcluster-in-ssh-mode
