### PR TITLE
Cluster.nodes update -> no longer return stopping/stopped spot instances

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -684,7 +684,7 @@ class Cluster(object):
             return n.spot_instance_request_id is None or \
                 n.state in ["running", "pending"]
 
-        nodes = filter(filterFct, nodes)  # filter stopping/stoped spot
+        nodes = filter(filterFct, nodes)  # filter stopping/stopped spot
         # remove any cached nodes not in the current node list from EC2
         current_ids = [n.id for n in nodes]
         remove_nodes = [n for n in self._nodes if n.id not in current_ids]

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -679,10 +679,12 @@ class Cluster(object):
         filters = {'group-name': self._security_group,
                    'instance-state-name': states}
         nodes = self.ec2.get_all_instances(filters=filters)
+
         def filterFct(n):
             return n.spot_instance_request_id is None or \
                 n.state in ["running", "pending"]
-        nodes = filter(filterFct, nodes)
+
+        nodes = filter(filterFct, nodes)  # filter stopping/stoped spot
         # remove any cached nodes not in the current node list from EC2
         current_ids = [n.id for n in nodes]
         remove_nodes = [n for n in self._nodes if n.id not in current_ids]

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -679,6 +679,10 @@ class Cluster(object):
         filters = {'group-name': self._security_group,
                    'instance-state-name': states}
         nodes = self.ec2.get_all_instances(filters=filters)
+        def filterFct(n):
+            return n.spot_instance_request_id is None or \
+                n.state in ["running", "pending"]
+        nodes = filter(filterFct, nodes)
         # remove any cached nodes not in the current node list from EC2
         current_ids = [n.id for n in nodes]
         remove_nodes = [n for n in self._nodes if n.id not in current_ids]


### PR DESCRIPTION
Stopping (stopped shouldn't really happen) spot nodes are clutter in the process since their destination is termination.
