### PR TITLE
217 not trying to delete root user anymore

### DIFF
--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -164,9 +164,13 @@ class DefaultClusterSetup(ClusterSetup):
         """
         user = user or self._user
         uid, gid = self._get_new_user_id(user)
-        log.info("Creating cluster user: %s (uid: %d, gid: %d)" %
-                 (user, uid, gid))
-        self._add_user_to_nodes(uid, gid, self._nodes)
+        if uid == 0 or gid == 0:
+            log.error("Cannot create user: %s (uid: %d, gid: %d). "
+                      "Trying to continue." % (user, uid, gid))
+        else:
+            log.info("Creating cluster user: %s (uid: %d, gid: %d)" %
+                     (user, uid, gid))
+            self._add_user_to_nodes(uid, gid, self._nodes)
 
     def _add_user_to_node(self, uid, gid, node):
         existing_user = node.getpwuid(uid)


### PR DESCRIPTION
Fixes an issue I have with StarCluster attempting to delete the root user, which fails. Once again if this is related to an improperly configured AMI you can kill that PR.
