### PR TITLE
config: allow user to specify config file via STARCLUSTER_CONFIG environment variable

### DIFF
--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -579,6 +579,13 @@ class StarClusterConfig(object):
                 awscreds[key] = os.environ.get(key.upper())
             elif key in os.environ:
                 awscreds[key] = os.environ.get(key)
+            elif key in static.AWS_SETTINGS_ALT_NAMES:
+                alt_name, callback = static.AWS_SETTINGS_ALT_NAMES[key]
+                value = os.environ.get(alt_name)
+                if callback:
+                    value = callback(value)
+                if value is not None:
+                    awscreds[key] = value
         return awscreds
 
     def get_aws_credentials(self):

--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -80,7 +80,9 @@ class StarClusterConfig(object):
     instance_types = static.INSTANCE_TYPES
 
     def __init__(self, config_file=None, cache=False):
-        self.cfg_file = config_file or static.STARCLUSTER_CFG_FILE
+        self.cfg_file = config_file \
+            or os.environ.get('STARCLUSTER_CONFIG') \
+            or static.STARCLUSTER_CFG_FILE
         self.cfg_file = os.path.expanduser(self.cfg_file)
         self.cfg_file = os.path.expandvars(self.cfg_file)
         self.type_validators = {

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -34,6 +34,8 @@ def create_sc_config_dirs():
 
 
 def __validate_ec2url(value):
+    if value is None:
+        return None
     return re.match('^https?://ec2\.[a-z0-9-]+\.amazonaws.com', value)
 
 

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -3,6 +3,7 @@ Module for storing static data structures
 """
 import os
 import sys
+import re
 import getpass
 import tempfile
 
@@ -30,6 +31,22 @@ def create_sc_config_dirs():
     __makedirs(STARCLUSTER_CFG_DIR, exit_on_failure=True)
     __makedirs(STARCLUSTER_PLUGIN_DIR)
     __makedirs(STARCLUSTER_LOG_DIR)
+
+
+def __validate_ec2url(value):
+    return re.match('^https?://ec2\.[a-z0-9-]+\.amazonaws.com', value)
+
+
+def __ec2url_region_name(value):
+    if not __validate_ec2url(value):
+        return None
+    return value.split('.')[1]
+
+
+def __ec2url_region_host(value):
+    if not __validate_ec2url(value):
+        return None
+    return value.split('://')[1]
 
 
 VERSION = "0.9999"
@@ -166,6 +183,14 @@ AWS_SETTINGS = {
     'aws_proxy_port': (int, False, None, None, None),
     'aws_proxy_user': (str, False, None, None, None),
     'aws_proxy_pass': (str, False, None, None, None),
+}
+
+# Alternate names (used by EC2 tools) for some of the above settings
+AWS_SETTINGS_ALT_NAMES = {
+    'aws_access_key_id': ('AWS_ACCESS_KEY', None),
+    'aws_secret_access_key': ('AWS_SECRET_KEY', None),
+    'aws_region_name': ('EC2_URL', __ec2url_region_name),
+    'aws_region_host': ('EC2_URL', __ec2url_region_host),
 }
 
 KEY_SETTINGS = {


### PR DESCRIPTION
Working in multiple projects/environments, each with slightly different StarCluster configurations. Being able set the config file through an environment variable is a major convenience, allowing to source a single file to switch between projects.
