### PR TITLE
config: config file path from STARCLUSTER_CONFIG env. variable

### DIFF
--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -80,7 +80,9 @@ class StarClusterConfig(object):
     instance_types = static.INSTANCE_TYPES
 
     def __init__(self, config_file=None, cache=False):
-        self.cfg_file = config_file or static.STARCLUSTER_CFG_FILE
+        self.cfg_file = config_file \
+            or os.environ.get('STARCLUSTER_CONFIG') \
+            or static.STARCLUSTER_CFG_FILE
         self.cfg_file = os.path.expanduser(self.cfg_file)
         self.cfg_file = os.path.expandvars(self.cfg_file)
         self.type_validators = {


### PR DESCRIPTION
Modified `StarClusterConfig.__init__()` to get the config file path from the `STARCLUSTER_CONFIG` environment variable. Useful in my case because I have separate AWS accounts/dev. environments for work and personal projects, and I already switch them by sourcing a file that changes shell environment variables. It would be nice to also change the StarCluster config file without having to supply "`-c <path>`" to every command or having to play symlink tricks with `~/.starcluster/config`.
