### PR TITLE
Remove #!/usr/bin/python

### DIFF
--- a/starcluster/progressbar.py
+++ b/starcluster/progressbar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: iso-8859-1 -*-
 #
 # progressbar  - Text progressbar library for python.


### PR DESCRIPTION
progressbar.py is a library file and is installed non-executable and so a #!/usr/bin/python is useless (and triggers a rpmlint warning).
