### PR TITLE
Load balancer minimal nodes >= 0

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -647,7 +647,7 @@ class SGELoadBalancer(LoadBalancer):
         total_slots = self.stat.count_total_slots()
         avail_slots = total_slots - used_slots
         need_to_add = 0
-        if total_slots == 0:
+        if total_slots == 0 and qw_slots > 0:
             #no slots, add one now
             need_to_add = 1
         elif qw_slots > avail_slots:

--- a/starcluster/commands/base.py
+++ b/starcluster/commands/base.py
@@ -153,6 +153,12 @@ class CmdBase(optcomplete.CmdComplete):
             parser.error("option %s must be a positive integer" % opt_str)
         setattr(parser.values, option.dest, value)
 
+    def _gte_0_int(self, option, opt_str, value, parser):
+        if value < 0:
+            parser.error("option %s must be an integer greater or equal to "
+                         "zero" % opt_str)
+        setattr(parser.values, option.dest, value)
+
     def _build_dict(self, option, opt_str, value, parser):
         tagdict = getattr(parser.values, option.dest)
         tags = value.split(',')

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -81,7 +81,7 @@ class CmdLoadBalance(ClusterCompleter):
                           help="Minutes to look back for past job history")
         parser.add_option("-n", "--min_nodes", dest="min_nodes",
                           action="callback", type="int", default=None,
-                          callback=self._positive_int,
+                          callback=self._gte_0_int,
                           help="Minimum number of nodes in cluster")
         parser.add_option("-K", "--kill-cluster", dest="kill_cluster",
                           action="store_true", default=False,


### PR DESCRIPTION
I need the load balancer to allow to run with a minimal nodes of 0. Hence, if I have no jobs in the queue, it's perfectly ok to have no worker nodes.

Also, I modified the condition to add immediately a node if the number of available slots = 0 to also check if there are waiting jobs.
