### PR TITLE
Support for --ignore-grp flag

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -387,7 +387,8 @@ class SGELoadBalancer(LoadBalancer):
     def __init__(self, interval=60, max_nodes=None, wait_time=900,
                  add_pi=1, kill_after=45, stab=180, lookback_win=3,
                  min_nodes=1, kill_cluster=False, plot_stats=False,
-                 plot_output_dir=None, dump_stats=False, stats_file=None):
+                 plot_output_dir=None, dump_stats=False, stats_file=None,
+                 ignore_grp=False):
         self._cluster = None
         self._keep_polling = True
         self._visualizer = None
@@ -408,6 +409,10 @@ class SGELoadBalancer(LoadBalancer):
         self.plot_output_dir = plot_output_dir
         if plot_stats:
             assert self.visualizer is not None
+        if ignore_grp:
+            self._placement_group = False
+        else:
+            self._placement_group = None
 
     @property
     def visualizer(self):
@@ -671,7 +676,8 @@ class SGELoadBalancer(LoadBalancer):
             log.warn("Adding %d nodes at %s" %
                      (need_to_add, str(datetime.datetime.utcnow())))
             try:
-                self._cluster.add_nodes(need_to_add)
+                self._cluster.add_nodes(need_to_add,
+                                        placement_group=self._placement_group)
                 self.__last_cluster_mod_time = datetime.datetime.utcnow()
                 log.info("Done adding nodes at %s" %
                          str(datetime.datetime.utcnow()))

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -805,16 +805,21 @@ class Cluster(object):
                          "following regions:\n%s" % cluster_regions)
                 log.warn("Instances will not be launched in a placement group")
                 placement_group = None
-            elif not placement_group:
+            elif placement_group is None:
+                #if placement_group is False -> leave false
                 placement_group = self.placement_group.name
+        availability_zone_group = None if placement_group is False \
+            else cluster_sg
+        #launch_group is related to placement group
+        launch_group = availability_zone_group
         image_id = image_id or self.node_image_id
         count = len(aliases) if not spot_bid else 1
         user_data = self._get_cluster_userdata(aliases)
         kwargs = dict(price=spot_bid, instance_type=instance_type,
                       min_count=count, max_count=count, count=count,
                       key_name=self.keyname, security_groups=[cluster_sg],
-                      availability_zone_group=cluster_sg,
-                      launch_group=cluster_sg,
+                      availability_zone_group=availability_zone_group,
+                      launch_group=launch_group,
                       placement=zone or getattr(self.zone, 'name', None),
                       user_data=user_data,
                       placement_group=placement_group)

--- a/starcluster/commands/addnode.py
+++ b/starcluster/commands/addnode.py
@@ -81,6 +81,10 @@ class CmdAddNode(ClusterCompleter):
             "-x", "--no-create", dest="no_create", action="store_true",
             default=False, help="do not launch new EC2 instances when "
             "adding nodes (use existing instances instead)")
+        parser.add_option(
+            "--ignore-grp", dest="ignore_grp", action="store_true",
+            default=False, help="if set, instances of type " +
+            str(static.CLUSTER_TYPES) + " will not use the placement group")
 
     def _get_duplicate(self, lst):
         d = {}
@@ -113,8 +117,12 @@ class CmdAddNode(ClusterCompleter):
         if not self.opts.alias and self.opts.no_create:
             self.parser.error("you must specify one or more node aliases via "
                               "the -a option when using -x")
+
+        placement_group = False if self.opts.ignore_grp else None
+
         self.cm.add_nodes(tag, num_nodes, aliases=aliases,
                           image_id=self.opts.image_id,
                           instance_type=self.opts.instance_type,
                           zone=self.opts.zone, spot_bid=self.opts.spot_bid,
-                          no_create=self.opts.no_create)
+                          no_create=self.opts.no_create,
+                          placement_group=placement_group)

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -1,5 +1,6 @@
 from starcluster import exception
 from starcluster.balancers import sge
+from starcluster import static
 
 from completers import ClusterCompleter
 
@@ -86,6 +87,10 @@ class CmdLoadBalance(ClusterCompleter):
         parser.add_option("-K", "--kill-cluster", dest="kill_cluster",
                           action="store_true", default=False,
                           help="Terminate the cluster when the queue is empty")
+        parser.add_option(
+            "--ignore-grp", dest="ignore_grp", action="store_true",
+            default=False, help="if set, instances of type " +
+            str(static.CLUSTER_TYPES) + " will not use the placement group")
 
     def execute(self, args):
         if not self.cfg.globals.enable_experimental:


### PR DESCRIPTION
I always use the --ignore-grp flag for my clusters because that way I'm sure to have the minimal spot price and it's faster to get instances. I made a clean patch for you to look at. I never tested it outside us-east-# so I don't know if it will work everywhere.
