### PR TITLE
faster CLI

### DIFF
--- a/starcluster/awsutils.py
+++ b/starcluster/awsutils.py
@@ -45,7 +45,7 @@ from starcluster.logger import log
 
 
 DEFAULT_CA_CERTS_FILE = os.path.join(
-    os.path.dirname(os.path.abspath(cacerts.__file__ )), "cacerts.txt")
+    os.path.dirname(os.path.abspath(cacerts.__file__)), "cacerts.txt")
 
 
 class EasyAWS(object):

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -42,27 +42,26 @@ from starcluster import spinner
 from starcluster import exception
 from starcluster.logger import log
 
-try:
-    import IPython
-    if IPython.__version__ < '0.11':
-        from IPython.Shell import IPShellEmbed
-        ipy_shell = IPShellEmbed(argv=[])
-    else:
-        from IPython import embed
-        ipy_shell = lambda local_ns=None: embed(user_ns=local_ns)
-except ImportError, e:
-
-    def ipy_shell(local_ns=None):
+def ipy_shell(local_ns=None):
+    try:
+        import IPython
+        if IPython.__version__ < '0.11':
+            from IPython.Shell import IPShellEmbed
+            return IPShellEmbed(argv=[])(local_ns)
+        else:
+            from IPython import embed
+            return embed(user_ns=local_ns)
+    except ImportError as e:
         log.error("Unable to load IPython:\n\n%s\n" % e)
         log.error("Please check that IPython is installed and working.")
         log.error("If not, you can install it via: easy_install ipython")
 
-try:
-    import pudb
-    set_trace = pudb.set_trace
-except ImportError:
 
-    def set_trace():
+def set_trace():
+    try:
+        import pudb
+        return pudb.set_trace()
+    except ImportError:
         log.error("Unable to load PuDB")
         log.error("Please check that PuDB is installed and working.")
         log.error("If not, you can install it via: easy_install pudb")

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -42,6 +42,7 @@ from starcluster import spinner
 from starcluster import exception
 from starcluster.logger import log
 
+
 def ipy_shell(local_ns=None):
     try:
         import IPython


### PR DESCRIPTION
Imports required for ipy_shell take a long time, so they are moved inside the function call in this PR.
For me (modern notebook with SSD) this change brings down time needed for "starcluster" command from 0.45s to 0.25s.
