### PR TITLE
Calling date --utc to fix default w/o it

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -477,7 +477,7 @@ class SGELoadBalancer(LoadBalancer):
         and returns a datetime object with the master's time
         instead of fetching it from local machine, maybe inaccurate.
         """
-        str = '\n'.join(self._cluster.master_node.ssh.execute('date'))
+        str = '\n'.join(self._cluster.master_node.ssh.execute('date --utc'))
         return datetime.datetime.strptime(str, "%a %b %d %H:%M:%S UTC %Y")
 
     def get_qatime(self, now):


### PR DESCRIPTION
Fix the following issue

**\* WARNING - Failed to retrieve stats (1/5):
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.94-py2.7.egg/starcluster/balancers/sge/**init**.py", line 572, in get_stats
    return self._get_stats()
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.94-py2.7.egg/starcluster/balancers/sge/__init__.py", line 538, in _get_stats
    now = self.get_remote_time()
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.94-py2.7.egg/starcluster/balancers/sge/__init__.py", line 517, in get_remote_time
    return datetime.datetime.strptime(str, "%a %b %d %H:%M:%S UTC %Y")
  File "/usr/lib/python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data 'Tue Aug 20 14:44:18 EDT 2013' does not match format '%a %b %d %H:%M:%S UTC %Y'
