### PR TITLE
Bugfix: availability_zone is stored in core

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -645,6 +645,7 @@ class Cluster(object):
                          master_instance_type=self.master_instance_type,
                          node_image_id=self.node_image_id,
                          node_instance_type=self.node_instance_type,
+                         availability_zone=self.availability_zone,
                          disable_queue=self.disable_queue,
                          disable_cloudinit=self.disable_cloudinit),
                     use_json=True)


### PR DESCRIPTION
Otherwise it's not available in the Cluster object returned by get_cluster.
