### PR TITLE
Bugfix: don't overwrite instance groupset with reservation groupset

### DIFF
--- a/starcluster/awsutils.py
+++ b/starcluster/awsutils.py
@@ -622,8 +622,8 @@ class EasyEC2(EasyAWS):
         for res in reservations:
             insts = res.instances
             for i in insts:
-                # set group info
-                i.groups = res.groups
+                # append group info
+                i.groups = list(set(i.groups).union(res.groups))
             instances.extend(insts)
         return instances
 


### PR DESCRIPTION
This can erase the instance's returned groups (via boto).  The proposed
solution is to take the union of the groups.
