### PR TITLE
Add support for the skip_detach tag in node.detach_external_volumes

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -849,6 +849,9 @@ class Node(object):
         for dev in block_devs:
             vol_id = block_devs[dev].volume_id
             vol = self.ec2.get_volume(vol_id)
+            if vol.tags.get('skip_detach', 'f').lower().startswith('t'):
+                log.info("Volume %s on %s is set to skip detach." % (vol.id, self.alias))
+                continue
             log.info("Detaching volume %s from %s" % (vol.id, self.alias))
             if vol.status not in ['available', 'detaching']:
                 vol.detach()


### PR DESCRIPTION
This allows plugins to perform the following steps:
- Create a volume from a snapshot
- Attach the volume to a node
- Set the volume to automatically delete when the node is stopped

The code looks like:

 vol = snapshot.create_volume(node.placement)
 vol.add_tag('skip_detach', 'true')
 vol.attach(node.id, attach_point)
 ec2.wait_for_volume(vol, state='attached')
 ec2.conn.modify_instance_attribute(
   node.id, 'blockDeviceMapping', ['%s=true' % attach_point])

The current behavior detaches this "temporary" volume before
the instance is terminated, and leaves ghost volumes sitting
around wasting money.

A future commit will include a plugin that uses this feature.
