### PR TITLE
ENH: Option to prefix dns name of clusters with the tag name.  ie master on mycluster --> mycluster-master.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,27 @@ Version History
 .. contents::
     :local:
 
+0.95
+====
+
+.. _v094-news:
+
+News
+----
+**TODO** Version 0.95 of StarCluster is...
+
+.. _v095-features:
+
+Features
+--------
+* Option to prefix dns names of created nodes with the cluster tag
+
+.. _v094-fixes:
+
+Bug Fixes
+---------
+* 
+
 .. _version-0.94:
 
 0.94

--- a/Changelog
+++ b/Changelog
@@ -19,6 +19,8 @@ News
 Features
 --------
 * Option to prefix dns names of created nodes with the cluster tag
+* Added --force option to removenode
+* Added -c <cluster_template> option to addnode and removenode
 
 .. _v094-fixes:
 

--- a/docs/sphinx/manual/configuration.rst
+++ b/docs/sphinx/manual/configuration.rst
@@ -318,6 +318,9 @@ template in detail.
 | cluster_shell        | No       | Sets the cluster user's shell (default: bash, options: bash, zsh, csh, ksh,     |
 |                      |          | tcsh)                                                                           |
 +----------------------+----------+---------------------------------------------------------------------------------+
+| dns_prefix           | No       | If True, prefixes the dns name of nodes with the cluster tag.
+|                      |          | For example:  master --> mycluster-master
++----------------------+----------+---------------------------------------------------------------------------------+
 | master_image_id      | No       | The AMI to use for the master node. (defaults to **node_image_id**)             |
 +----------------------+----------+---------------------------------------------------------------------------------+
 | master_instance_type | No       | The instance type for the master node. (defaults to **node_instance_type**)     |

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -168,8 +168,10 @@ class ClusterManager(managers.Manager):
 
     def add_node(self, cluster_name, dns_prefix, alias=None, no_create=False,
                  image_id=None, instance_type=None, zone=None,
-                 placement_group=None, spot_bid=None):
-        cl = self.get_cluster(cluster_name)
+                 placement_group=None, spot_bid=None, template=None):
+        if not template:
+            template = self.get_default_cluster_template()
+        cl = self.get_cluster_template(template, cluster_name)
         if dns_prefix:
             cl.dns_prefix = cluster_name
         return cl.add_node(alias=alias, image_id=image_id,
@@ -180,11 +182,13 @@ class ClusterManager(managers.Manager):
     def add_nodes(self, cluster_name, num_nodes, dns_prefix, aliases=None,
                   no_create=False,
                   image_id=None, instance_type=None, zone=None,
-                  placement_group=None, spot_bid=None):
+                  placement_group=None, spot_bid=None, template=None):
         """
         Add one or more nodes to cluster
         """
-        cl = self.get_cluster(cluster_name)
+        if not template:
+            template = self.get_default_cluster_template()
+        cl = self.get_cluster_template(template, cluster_name)
         if dns_prefix:
             cl.dns_prefix = cluster_name
         return cl.add_nodes(num_nodes, aliases=aliases, image_id=image_id,
@@ -192,15 +196,18 @@ class ClusterManager(managers.Manager):
                             placement_group=placement_group, spot_bid=spot_bid,
                             no_create=no_create)
 
-    def remove_node(self, cluster_name, alias, terminate=True):
+    def remove_node(self, cluster_name, alias, terminate=True, template=None,
+                    force=False):
         """
         Remove a single node from a cluster
         """
-        cl = self.get_cluster(cluster_name)
+        if not template:
+            template = self.get_default_cluster_template()
+        cl = self.get_cluster_template(template, cluster_name)
         n = cl.get_node_by_alias(alias)
         if not n:
             raise exception.InstanceDoesNotExist(alias, label='node')
-        cl.remove_node(n, terminate=terminate)
+        cl.remove_node(n, terminate=terminate, force=force)
 
     def restart_cluster(self, cluster_name, reboot_only=False):
         """
@@ -941,21 +948,25 @@ class Cluster(object):
             node = self.get_node_by_alias(alias)
             self.run_plugins(method_name="on_add_node", node=node)
 
-    def remove_node(self, node, terminate=True):
+    def remove_node(self, node, terminate=True, force=False):
         """
         Remove a single node from this cluster
         """
-        return self.remove_nodes([node], terminate=terminate)
+        return self.remove_nodes([node], terminate=terminate, force=force)
 
-    def remove_nodes(self, nodes, terminate=True):
+    def remove_nodes(self, nodes, terminate=True, force=False):
         """
         Remove a list of nodes from this cluster
         """
         for node in nodes:
             if node.is_master():
                 raise exception.InvalidOperation("cannot remove master node")
-            self.run_plugins(method_name="on_remove_node",
-                             node=node, reverse=True)
+            try:
+                self.run_plugins(method_name="on_remove_node",
+                                node=node, reverse=True)
+            except:
+                if not force:
+                    raise
             if not terminate:
                 continue
             node.terminate()

--- a/starcluster/commands/addnode.py
+++ b/starcluster/commands/addnode.py
@@ -74,6 +74,9 @@ class CmdAddNode(ClusterCompleter):
             "-a", "--alias", dest="alias", action="append", type="string",
             default=[], help="alias to give to the new node "
             "(e.g. node007, mynode, etc.)")
+        parser.add_option("-P", "--dns-prefix", action='store_true',
+                          help=("Prefix dns names of all added nodes"
+                                " with the cluster tag"))
         parser.add_option(
             "-n", "--num-nodes", dest="num_nodes", action="store", type="int",
             default=1, help="number of new nodes to launch")
@@ -115,8 +118,9 @@ class CmdAddNode(ClusterCompleter):
         aliases = []
         for alias in self.opts.alias:
             aliases.extend(alias.split(','))
-        if 'master' in aliases:
-            self.parser.error("'master' is a reserved alias")
+        if ('master' in aliases) or ('%s-master' % tag in aliases):
+            self.parser.error(
+                "'master' and '%s-master' are reserved aliases" % tag)
         num_nodes = self.opts.num_nodes
         if num_nodes == 1 and aliases:
             num_nodes = len(aliases)
@@ -134,4 +138,5 @@ class CmdAddNode(ClusterCompleter):
                           image_id=self.opts.image_id,
                           instance_type=self.opts.instance_type,
                           zone=self.opts.zone, spot_bid=self.opts.spot_bid,
-                          no_create=self.opts.no_create)
+                          no_create=self.opts.no_create,
+                          dns_prefix=self.opts.dns_prefix)

--- a/starcluster/commands/addnode.py
+++ b/starcluster/commands/addnode.py
@@ -70,6 +70,13 @@ class CmdAddNode(ClusterCompleter):
     tag = None
 
     def addopts(self, parser):
+        templates = []
+        if self.cfg:
+            templates = self.cfg.clusters.keys()
+        parser.add_option(
+            "-c", "--cluster-template", action="store",
+            dest="cluster_template", choices=templates, default=None,
+            help="cluster template to use from the config file")
         parser.add_option(
             "-a", "--alias", dest="alias", action="append", type="string",
             default=[], help="alias to give to the new node "
@@ -139,4 +146,5 @@ class CmdAddNode(ClusterCompleter):
                           instance_type=self.opts.instance_type,
                           zone=self.opts.zone, spot_bid=self.opts.spot_bid,
                           no_create=self.opts.no_create,
-                          dns_prefix=self.opts.dns_prefix)
+                          dns_prefix=self.opts.dns_prefix,
+                          template=self.opts.cluster_template)

--- a/starcluster/commands/removenode.py
+++ b/starcluster/commands/removenode.py
@@ -49,6 +49,16 @@ class CmdRemoveNode(ClusterCompleter):
     tag = None
 
     def addopts(self, parser):
+        templates = []
+        if self.cfg:
+            templates = self.cfg.clusters.keys()
+        parser.add_option(
+            "-c", "--cluster-template", action="store",
+            dest="cluster_template", choices=templates, default=None,
+            help="cluster template to use from the config file")
+        parser.add_option("-f", "--force", dest="force", action="store_true",
+                          default=False,  help="Terminate node regardless "
+                          "of errors if possible ")
         parser.add_option("-k", "--keep-instance", dest="terminate",
                           action="store_false", default=True,
                           help="do not terminate instances "
@@ -60,4 +70,6 @@ class CmdRemoveNode(ClusterCompleter):
         tag = self.tag = args[0]
         aliases = args[1:]
         for alias in aliases:
-            self.cm.remove_node(tag, alias, terminate=self.opts.terminate)
+            self.cm.remove_node(tag, alias, terminate=self.opts.terminate,
+                                template=self.opts.cluster_template,
+                                force=self.opts.force)

--- a/starcluster/commands/sshmaster.py
+++ b/starcluster/commands/sshmaster.py
@@ -45,13 +45,19 @@ class CmdSshMaster(ClusterCompleter):
         parser.add_option("-A", "--forward-agent", dest="forward_agent",
                           action="store_true", default=False,
                           help="enable authentication agent forwarding")
+        parser.add_option("-P", "--dns-prefix", action="store_true",
+                          help=("Let starcluster know that the master's dns"
+                                " name starts with the tag name.  ie: "
+                                " mycluster-master."))
 
     def execute(self, args):
         if not args:
             self.parser.error("please specify a cluster")
         clname = args[0]
         cmd = ' '.join(args[1:])
-        retval = self.cm.ssh_to_master(clname, user=self.opts.user,
+        retval = self.cm.ssh_to_master(clname,
+                                       dns_prefix=self.opts.dns_prefix,
+                                       user=self.opts.user,
                                        command=cmd,
                                        forward_x11=self.opts.forward_x11,
                                        forward_agent=self.opts.forward_agent)

--- a/starcluster/commands/start.py
+++ b/starcluster/commands/start.py
@@ -153,6 +153,9 @@ class CmdStart(ClusterCompleter):
                           action="append", default=None, metavar="FILE",
                           help="Path to userdata script that will run on "
                           "each node on start-up. Can be used multiple times.")
+        parser.add_option("-P", "--dns-prefix", action='store_true',
+                          help=("Prefix dns names of all nodes in the cluster"
+                                "with the cluster tag"))
 
     def execute(self, args):
         if len(args) != 1:
@@ -209,6 +212,8 @@ class CmdStart(ClusterCompleter):
                                        'tag': tag}
             if not validate_only and not create_only:
                 self.warn_experimental(msg, num_secs=5)
+        if self.opts.dns_prefix:
+            scluster.dns_prefix = tag
         try:
             scluster.start(create=create, create_only=create_only,
                            validate=validate, validate_only=validate_only,

--- a/starcluster/commands/terminate.py
+++ b/starcluster/commands/terminate.py
@@ -50,6 +50,11 @@ class CmdTerminate(ClusterCompleter):
         parser.add_option("-f", "--force", dest="force", action="store_true",
                           default=False,  help="Terminate cluster regardless "
                           "of errors if possible ")
+        parser.add_option("-P", "--dns-prefix", action="store_true",
+                          help=("Let starcluster know that the master's dns"
+                                " name starts with the tag name.  ie: "
+                                " mycluster-master.  This is only necessary if"
+                                " you prefix nodes with the cluster tag"))
 
     def _terminate_cluster(self, cl):
         if not self.opts.confirm:
@@ -81,6 +86,8 @@ class CmdTerminate(ClusterCompleter):
         try:
             cl = self.cm.get_cluster(cluster_name, load_receipt=not force,
                                      require_keys=not force)
+            if self.opts.dns_prefix:
+                cl.dns_prefix = cluster_name
             if force:
                 self._terminate_manually(cl)
             else:

--- a/starcluster/exception.py
+++ b/starcluster/exception.py
@@ -211,6 +211,10 @@ class InvalidIsoDate(BaseException):
         self.msg = "Invalid date specified: %s" % date
 
 
+class InvalidHostname(BaseException):
+    pass
+
+
 class ConfigError(BaseException):
     """Base class for all config related errors"""
 

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -241,4 +241,5 @@ CLUSTER_SETTINGS = {
     'disable_queue': (bool, False, False, None, None),
     'force_spot_master': (bool, False, False, None, None),
     'disable_cloudinit': (bool, False, False, None, None),
+    'dns_prefix': (bool, False, False, None, None),
 }

--- a/starcluster/templates/config.py
+++ b/starcluster/templates/config.py
@@ -100,6 +100,11 @@ CLUSTER_USER = sgeadmin
 # optionally specify shell (defaults to bash)
 # (options: %(shells)s)
 CLUSTER_SHELL = bash
+# Uncomment to prepent the cluster tag to the dns name of all nodes created
+# using this cluster config.  ie: mycluster-master and mycluster-node001
+# If you choose to enable this option, it's recommended that you enable it in
+# the DEFAULT_TEMPLATE so all nodes will automatically have the prefix
+# DNS_PREFIX = True
 # AMI to use for cluster nodes. These AMIs are for the us-east-1 region.
 # Use the 'listpublic' command to list StarCluster AMIs in other regions
 # The base i386 StarCluster AMI is %(x86_ami)s

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -179,6 +179,20 @@ def is_valid_image_name(image_name):
         return False
 
 
+def is_valid_hostname(hostname):
+    """From StackOverflow on 2013-10-04:
+
+    http://stackoverflow.com
+    /questions/2532053/validate-a-hostname-string#answer-2532344
+    """
+    if len(hostname) > 255:
+        return False
+    if hostname[-1] == ".":
+        hostname = hostname[:-1]  # strip exactly one dot from the right
+    allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(allowed.match(x) for x in hostname.split("."))
+
+
 def make_one_liner(script):
     """
     Returns command to execute python script as a one-line python program


### PR DESCRIPTION
Hi,  

This PR is a collection of a couple different improvements.  The PR is backwards compatible and contains:
- 1st commit: optparse and config option to prefix host names.
- 2nd commit: optparse option in removenode and addnode to use a specific template (so plugin on_shutdown runs properly)
  - optparse option -f to force shutdown on removenode even if sge and other plugins fail  

The first commit adds the option to prefix dns hostnames with the cluster tag.  I wrote about this a little while ago on the mailing list and finally had some time today to do this.   http://star.mit.edu/cluster/mlarchives/1820.html

```
Specifically, if you have a cluster named "mycluster" and set the option the prefix dns names with the cluster tag, the new naming scheme would be:
   master --> mycluster-master
   node001 --> mycluster-node001 
```

The second commit adds the options to use a template defined in your starcluster config on addnode and removenode, so that the appropriate cluster settings are used when you add/remove nodes from the cluster

```
starcluster addnode -c myconfig ...
```

The second commit also adds a --force option to removenode that terminates the node whether or not the plugins close successfully

Please take a look and let me know what you think!  I also started 0.95 in the Changelog.

Alex
