### PR TITLE
Plugin for configuring s3cmd and ~/.s3cfg file

### DIFF
--- a/docs/sphinx/plugins/index.rst
+++ b/docs/sphinx/plugins/index.rst
@@ -11,6 +11,7 @@ The links below are for plugin-specific docs. Please see the :ref:`plugin guide
    users
    ipython
    boto
+   s3cmd
    tmux
    condor
    hadoop

--- a/docs/sphinx/plugins/s3cmd.rst
+++ b/docs/sphinx/plugins/s3cmd.rst
@@ -1,0 +1,53 @@
+.. _s3cmd-plugin:
+
+###########
+S3cmd Plugin
+###########
+
+.. _s3cmd: http://s3tools.org/s3cmd
+
+This plugin configures a $HOME/.s3cfg config file for the s3cmd_ utility in
+the ``CLUSTER_USER``. It supports both copying an existing .s3cfg config file
+and auto-generating a config file using the currently active StarCluster
+credentials.
+
+To use this plugin you must first define it in the StarCluster config file:
+
+.. code-block:: ini
+
+    [plugin s3cmd]
+    setup_class = starcluster.plugins.s3cmd.S3CmdPlugin
+
+By default the plugin auto-generates a .s3cmd config file for you using the
+currently active AWS credentials and default options as set by s3cmd
+at the time the plugin is executed. If you'd prefer to copy your own
+config file instead add the ``s3cmd_cfg`` setting:
+
+.. code-block:: ini
+
+    [plugin s3cmd]
+    setup_class = starcluster.plugins.s3cmd.S3CmdPlugin
+    s3cmd_cfg = /path/to/your/s3cmd/.s3cfg
+
+Once you've defined the plugin in your config, add the s3cmd plugin to the list
+of plugins in one of your cluster templates:
+
+.. code-block:: ini
+
+    [cluster smallcluster]
+    plugins = s3cmd
+
+Now whenever you start a cluster using that cluster template the
+``CLUSTER_USER`` will automatically be configured to use s3cmd.
+
+Additional options for s3cmd can be included in the ``[plugin s3cmd]`` block:
+
+.. code-block:: ini
+
+    [plugin s3cmd]
+    setup_class = starcluster.plugins.s3cmd.S3CmdPlugin
+    gpg_command = /path/to/gpg
+    gpg_passphrase = my_gpg_passphrase
+    use_https = True
+
+These options are then written into the .s3cfg configure file.

--- a/starcluster/plugins/__init__.py
+++ b/starcluster/plugins/__init__.py
@@ -27,4 +27,5 @@ __all__ = [
     'pypkginstaller',
     'xvfb',
     'mpich2',
+    's3cmd',
 ]

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -84,9 +84,8 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
         self.config_dict["use_https"] = use_https
 
     def run(self, nodes, master, user, shell, volumes):
-        conn = master.ec2._conn
-        self.config_dict["aws_access_key_id"] = conn.aws_access_key_id
-        self.config_dict["aws_secret_access_key"] = conn.aws_secret_access_key
+        self.config_dict["aws_access_key_id"] = master.ec2.aws_access_key_id
+        self.config_dict["aws_secret_access_key"] = master.ec2.aws_secret_access_key
         mssh = master.ssh
         mssh.switch_user(user)
         s3cmd_cfg = "/home/%s/.s3cfg" % user

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -84,8 +84,10 @@ class S3CmdPlugin(clustersetup.ClusterSetup):
         self.config_dict["use_https"] = use_https
 
     def run(self, nodes, master, user, shell, volumes):
-        self.config_dict["aws_access_key_id"] = master.ec2.aws_access_key_id
-        self.config_dict["aws_secret_access_key"] = master.ec2.aws_secret_access_key
+        self.config_dict["aws_access_key_id"] = \
+            master.ec2.aws_access_key_id
+        self.config_dict["aws_secret_access_key"] = \
+            master.ec2.aws_secret_access_key
         mssh = master.ssh
         mssh.switch_user(user)
         s3cmd_cfg = "/home/%s/.s3cfg" % user

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -1,0 +1,102 @@
+# Copyright 2009-2013 Justin Riley
+#
+# This file is part of StarCluster.
+#
+# StarCluster is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# StarCluster is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StarCluster. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from starcluster import clustersetup
+from starcluster.logger import log
+
+
+s3cmd_cfg_TEMPLATE = """\
+[default]
+access_key = %(aws_access_key_id)s
+bucket_location = US
+cloudfront_host = cloudfront.amazonaws.com
+default_mime_type = binary/octet-stream
+delete_removed = False
+dry_run = False
+enable_multipart = True
+encoding = UTF-8
+encrypt = False
+follow_symlinks = False
+force = False
+get_continue = False
+gpg_command = %(gpg_command)s
+gpg_decrypt = %(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
+gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
+gpg_passphrase = %(gpg_passphrase)s
+guess_mime_type = True
+host_base = s3.amazonaws.com
+host_bucket = %%(bucket)s.s3.amazonaws.com
+human_readable_sizes = False
+invalidate_on_cf = False
+list_md5 = False
+log_target_prefix = 
+mime_type = 
+multipart_chunk_size_mb = 15
+preserve_attrs = True
+progress_meter = True
+proxy_host = 
+proxy_port = 0
+recursive = False
+recv_chunk = 4096
+reduced_redundancy = False
+secret_key = %(aws_secret_access_key)s
+send_chunk = 4096
+simpledb_host = sdb.amazonaws.com
+skip_existing = False
+socket_timeout = 300
+urlencoding_mode = normal
+use_https = %(use_https)s
+verbosity = WARNING
+website_endpoint = http://%%(bucket)s.s3-website-%%(location)s.amazonaws.com/
+website_error = 
+website_index = index.html
+"""
+
+
+class S3cmdPlugin(clustersetup.ClusterSetup):
+    """
+    Plugin that configures a ~/.s3cfg file for CLUSTER_USER
+    """
+    def __init__(self, s3cmd_cfg=None, gpg_command='/usr/bin/gpg', gpg_passphrase="", use_https=False):
+        self.s3cmd_cfg = os.path.expanduser(s3cmd_cfg or '') or None
+        self.config_dict = {}
+        self.config_dict["gpg_command"] = gpg_command
+        self.config_dict["gpg_passphrase"] = gpg_passphrase
+        self.config_dict["use_https"] = use_https
+        
+
+    def run(self, nodes, master, user, shell, volumes):
+        self.config_dict["aws_access_key_id"] = master.ec2._conn.aws_access_key_id
+        self.config_dict["aws_secret_access_key"] = master.ec2._conn.aws_secret_access_key
+        mssh = master.ssh
+        mssh.switch_user(user)
+        s3cmd_cfg = "/home/%s/.s3cfg" % user
+        if not mssh.path_exists(s3cmd_cfg):
+            log.info("Installing .s3cfg file for user: %s" % user)
+            if self.s3cmd_cfg:
+                log.info("Copying %s to %s" % (self.s3cmd_cfg, s3cmd_cfg))
+                mssh.put(self.s3cmd_cfg, s3cmd_cfg)
+            else:
+                log.info("Installing new .s3cfg to: %s" % s3cmd_cfg)
+                f = mssh.remote_file(s3cmd_cfg, 'w')
+                f.write(s3cmd_cfg_TEMPLATE % self.config_dict)
+                f.close()
+            mssh.chmod(0400, s3cmd_cfg)
+        else:
+            log.warn("AWS credentials already present - skipping install")

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -36,8 +36,10 @@ follow_symlinks = False
 force = False
 get_continue = False
 gpg_command = %(gpg_command)s
-gpg_decrypt = %(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
-gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
+gpg_decrypt = %(gpg_command)s -d --verbose --no-use-agent --batch\
+ --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
+gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch\
+ --yes --passphrase-fd %%(passphrase_fd)s -o %%(output_file)s %%(input_file)s
 gpg_passphrase = %(gpg_passphrase)s
 guess_mime_type = True
 host_base = s3.amazonaws.com
@@ -45,12 +47,12 @@ host_bucket = %%(bucket)s.s3.amazonaws.com
 human_readable_sizes = False
 invalidate_on_cf = False
 list_md5 = False
-log_target_prefix = 
-mime_type = 
+log_target_prefix =
+mime_type =
 multipart_chunk_size_mb = 15
 preserve_attrs = True
 progress_meter = True
-proxy_host = 
+proxy_host =
 proxy_port = 0
 recursive = False
 recv_chunk = 4096
@@ -64,7 +66,7 @@ urlencoding_mode = normal
 use_https = %(use_https)s
 verbosity = WARNING
 website_endpoint = http://%%(bucket)s.s3-website-%%(location)s.amazonaws.com/
-website_error = 
+website_error =
 website_index = index.html
 """
 
@@ -73,17 +75,18 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
     """
     Plugin that configures a ~/.s3cfg file for CLUSTER_USER
     """
-    def __init__(self, s3cmd_cfg=None, gpg_command='/usr/bin/gpg', gpg_passphrase="", use_https=False):
+    def __init__(self, s3cmd_cfg=None, gpg_command='/usr/bin/gpg',
+                 gpg_passphrase="", use_https=False):
         self.s3cmd_cfg = os.path.expanduser(s3cmd_cfg or '') or None
         self.config_dict = {}
         self.config_dict["gpg_command"] = gpg_command
         self.config_dict["gpg_passphrase"] = gpg_passphrase
         self.config_dict["use_https"] = use_https
-        
 
     def run(self, nodes, master, user, shell, volumes):
-        self.config_dict["aws_access_key_id"] = master.ec2._conn.aws_access_key_id
-        self.config_dict["aws_secret_access_key"] = master.ec2._conn.aws_secret_access_key
+        conn = master.ec2._conn
+        self.config_dict["aws_access_key_id"] = conn.aws_access_key_id
+        self.config_dict["aws_secret_access_key"] = conn.aws_secret_access_key
         mssh = master.ssh
         mssh.switch_user(user)
         s3cmd_cfg = "/home/%s/.s3cfg" % user
@@ -99,4 +102,4 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
                 f.close()
             mssh.chmod(0400, s3cmd_cfg)
         else:
-            log.warn("S3cmd configuration file already present - skipping install")
+            log.warn("~/.s3cfg file already present - skipping install")

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -88,7 +88,7 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
         mssh.switch_user(user)
         s3cmd_cfg = "/home/%s/.s3cfg" % user
         if not mssh.path_exists(s3cmd_cfg):
-            log.info("Installing .s3cfg file for user: %s" % user)
+            log.info("Installing ~/.s3cfg file for user: %s" % user)
             if self.s3cmd_cfg:
                 log.info("Copying %s to %s" % (self.s3cmd_cfg, s3cmd_cfg))
                 mssh.put(self.s3cmd_cfg, s3cmd_cfg)
@@ -99,4 +99,4 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
                 f.close()
             mssh.chmod(0400, s3cmd_cfg)
         else:
-            log.warn("AWS credentials already present - skipping install")
+            log.warn("S3cmd configuration file already present - skipping install")

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -90,7 +90,7 @@ class S3cmdPlugin(clustersetup.ClusterSetup):
         mssh.switch_user(user)
         s3cmd_cfg = "/home/%s/.s3cfg" % user
         if not mssh.path_exists(s3cmd_cfg):
-            log.info("Installing ~/.s3cfg file for user: %s" % user)
+            log.info("Configuring s3cmd for user: %s" % user)
             if self.s3cmd_cfg:
                 log.info("Copying %s to %s" % (self.s3cmd_cfg, s3cmd_cfg))
                 mssh.put(self.s3cmd_cfg, s3cmd_cfg)

--- a/starcluster/plugins/s3cmd.py
+++ b/starcluster/plugins/s3cmd.py
@@ -71,7 +71,7 @@ website_index = index.html
 """
 
 
-class S3cmdPlugin(clustersetup.ClusterSetup):
+class S3CmdPlugin(clustersetup.ClusterSetup):
     """
     Plugin that configures a ~/.s3cfg file for CLUSTER_USER
     """


### PR DESCRIPTION
This plugin is based heavily on the boto plugin for StarCluster. It creates a .s3cfg file based on the default s3cmd template in the CLUSTER_USER home directory. The plugin can be configured to optionally use gpg and/or https (just as `s3cmd --configure` would allow) and grabs the `aws_access_key_id` and `aws_secret_access_key` from the `master.ec2._conn` object (note: this is a change from the boto.py script-- see my issue regarding this filed separately). 

Default plugin configuration:

``` shell
[plugin s3cmd]
setup_class = s3cmd.S3cmdPlugin
```

with optional parameters:

``` bash
gpg_command = /path/to/gpg
gpg_passphrase = mypassphrase
use_https = True
```

Future upgrades:
- ability to create this file for all users
- parameterize other s3cmd options
- install newer version of s3cmd (not via apt-get or yum, as these are outdate)
