### PR TITLE
BUG Fix intermittent bug where new-window -t is called before new-session has finished

### DIFF
--- a/starcluster/plugins/tmux.py
+++ b/starcluster/plugins/tmux.py
@@ -78,7 +78,7 @@ class TmuxControlCenter(clustersetup.DefaultClusterSetup):
         node.ssh.execute('tmux send-keys -t %s:%s "Enter"' % (envname, window))
 
     def _new_session(self, node, envname):
-        node.ssh.execute('tmux new-session -d -s %s' % envname, detach=True)
+        node.ssh.execute('tmux new-session -d -s %s' % envname)
 
     def _kill_session(self, node, envname):
         node.ssh.execute('tmux kill-session -t %s' % envname)


### PR DESCRIPTION
Sometimes, 

starcluster runplugin tmux mycluster 

fails because the new-session command is run in the background and new-window runs immediately after it.  I think this fixes the problem.  At the very least, detach=True is unnecessary.
