### PR TITLE
Fixing typo

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -1020,7 +1020,7 @@ class Node(object):
         if self.instance.vpc_id:
             #if instance has an elastic ip
             if self.instance.ip_address:
-                return self.instance.ip_adress
+                return self.instance.ip_address
             else:
                 return self.instance.private_ip_address
         else:


### PR DESCRIPTION
Missing "d" in ip_address causing an error when starting a new cluster.
