### PR TITLE
add support for new GRID GPU g2.2xlarge (non-GPGPU) instance type

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -123,6 +123,7 @@ INSTANCE_TYPES = {
     'cc1.4xlarge': ['x86_64'],
     'cc2.8xlarge': ['x86_64'],
     'cg1.4xlarge': ['x86_64'],
+    'g2.2xlarge': ['x86_64'],
     'cr1.8xlarge': ['x86_64'],
     'hi1.4xlarge': ['x86_64'],
     'hs1.8xlarge': ['x86_64'],
@@ -136,6 +137,8 @@ CLUSTER_COMPUTE_TYPES = ['cc1.4xlarge', 'cc2.8xlarge']
 
 CLUSTER_GPU_TYPES = ['cg1.4xlarge']
 
+GRID_GPU_TYPES = ['g2.2xlarge']
+
 CLUSTER_HIMEM_TYPES = ['cr1.8xlarge']
 
 HI_IO_TYPES = ['hi1.4xlarge']
@@ -144,7 +147,7 @@ HI_STORAGE_TYPES = ['hs1.8xlarge']
 
 CLUSTER_TYPES = CLUSTER_COMPUTE_TYPES + CLUSTER_GPU_TYPES + CLUSTER_HIMEM_TYPES
 
-HVM_TYPES = CLUSTER_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES
+HVM_TYPES = CLUSTER_TYPES + GRID_GPU_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES
 
 PLACEMENT_GROUP_TYPES = CLUSTER_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES
 


### PR DESCRIPTION
Support for new GRID GPU g2.2xlarge instance type, which has the following features:
- 64-bit HVM instance type
- non-GPGPU (GPU only supports single-precision FP, and no ECC graphics memory)

Can be useful for scientific visualization, or graphics rendering.
