### PR TITLE
ENH: Use DNS server on master to resolve hostnames (instead of /etc/hosts)

### DIFF
--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -367,6 +367,32 @@ class DefaultClusterSetup(ClusterSetup):
             master.export_fs_to_nodes(nodes, export_paths)
             self._mount_nfs_shares(nodes, export_paths=export_paths)
 
+    def _setup_dns(self, nodes=None, start_server=False):
+        """
+        0. Install dnsmasq on master if start_server == True
+        1. Add host to master's /etc/hosts (so dnsmasq can resolve it)
+        2. Add a new 'prepend domain-name-servers' entry to
+           /etc/dhcp/dhclient.conf with IP address of master node
+        3. Restart eth0 network interface to make changes propagate to 
+           /etc/resolv.conf
+        """
+        log.info("Setting up DNS-based hostname resolving")
+        if start_server:
+            log.debug("Installing/starting DNS server (dnsmasq) on master")
+            self._master.apt_install("dnsmasq")
+        
+        log.debug("Adding nodes to /etc/hosts on master")
+        nodes = nodes or self._nodes
+        self._master.add_to_etc_hosts(nodes)
+
+        log.debug("Setting up DNS nameserver on each node")
+        
+        for node in nodes:
+            self.pool.simple_job(node.setup_dns,
+                                 (self._master.private_ip_address, ),
+                                 jobid=node.alias)
+
+
     def run(self, nodes, master, user, user_shell, volumes):
         """Start cluster configuration"""
         self._nodes = nodes
@@ -378,7 +404,7 @@ class DefaultClusterSetup(ClusterSetup):
         self._setup_ebs_volumes()
         self._setup_cluster_user()
         self._setup_scratch()
-        self._setup_etc_hosts()
+        self._setup_dns(start_server=True)
         self._setup_nfs()
         self._setup_passwordless_ssh()
 
@@ -405,8 +431,8 @@ class DefaultClusterSetup(ClusterSetup):
         log.info("Removing node %s (%s)..." % (node.alias, node.id))
         log.info("Removing %s from known_hosts files" % node.alias)
         self._remove_from_known_hosts(node)
-        log.info("Removing %s from /etc/hosts" % node.alias)
-        self._remove_from_etc_hosts(node)
+        log.info("Removing %s from DNS (/etc/hosts on master)" % node.alias)
+        self._master.remove_from_etc_hosts([node])
         log.info("Removing %s from NFS" % node.alias)
         self._remove_nfs_exports(node)
 
@@ -422,7 +448,7 @@ class DefaultClusterSetup(ClusterSetup):
         self._user_shell = user_shell
         self._volumes = volumes
         self._setup_hostnames(nodes=[node])
-        self._setup_etc_hosts(nodes)
+        self._setup_dns(nodes=[node], start_server=False)
         self._setup_nfs(nodes=[node], start_server=False)
         self._create_user(node)
         self._setup_scratch(nodes=[node])

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -826,6 +826,25 @@ class Node(object):
             else:
                 raise
 
+    def setup_dns(self, nameserver_ip):
+        """
+        1. Add new "prepend domain-name-servers" directive to 
+            /etc/dhcp/dhclient.conf
+        2. Restart network interface to make changes apply. A nameserver
+            entry is added to /etc/resolv.conf (Warning: /etc/resolv.conf is 
+            updated dynamically-- changes to it will NOT hold).
+        2. Add entry for current node to /etc/hosts. This is required for SGE 
+            compatibility
+        """
+        self.ssh.execute(
+            "echo \"prepend domain-name-servers %s;\" >> "
+            "/etc/dhcp/dhclient.conf"
+            " && service network-interface restart INTERFACE=eth0" % nameserver_ip)
+
+        # required for SGE compatibility
+        self.add_to_etc_hosts([self])
+
+
     @property
     def network_names(self):
         """ Returns all network names for this node in a dictionary"""


### PR DESCRIPTION
Hi all,

I'd love to get some early feedback on this enhancement, which replaces the time-consuming process of updating all /etc/hosts files on all the nodes every time a node is added or removed. In my experience, with large clusters (100+ nodes), this process can take hours. In this PR, I replace the reliance on /etc/hosts with a DNS a simple DNS server on the master node, and add a new "prepend domain-name-servers" entry to /etc/dhcp/dhclient.conf on all nodes. This bypasses the O((N^2)/2) operation required to update all the /etc/hosts on all nodes when adding or removing N nodes. Instead, only the /etc/hosts file on master must be updated.

A couple of clarifications/notes:

1) The /etc/hosts file must still contain the entry for the node itself, as SGE's /opt/sge6/utilbin/linux-x64/gethostname requires this (and SGE install will fail without this present)
2) Typically, one can specify a "nameserver" entry in /etc/resolv.conf, but because this file is frequently overwritten on AWS (when DHCP updates, for example), DNS nameserver settings need to be registered in the dhclient.conf file instead.

Other thoughts:
- Although this seems to work quite well in my hands, I'd love feedback on how to best implement the addition of the lines to /etc/dhcp/dhclient.conf. The way it works now (sed find/replace) seems brittle at best...
- The DNSmasq server could probably be included with the AMI and started by default on all images with no harm. But perhaps we would want this to be more configurable? I'm not terribly familiar with DNS and so don't know offhand what people would like to configure.
- What kind of issues would this run into with the VPC branch? I took a quick look and it seems as if StarCluster-VPC still makes use of the /etc/hosts arrangement, but I could be wrong. 
- The option to use DNS should probably be a configurable option in the StarCluster config file, but i've left that out for now.
- Documentation: pending!
- Lastly, there are a few other lengthy operations done when adding or removing nodes that become very costly with large clusters (e.g., updating the total # of slots/cpus available in SGE). These can be bypassed in similar ways, but I left them out of this PR for now. In the future, i'll submit a "large cluster performance support" PR for those.

Thanks for reading, happy to take feedback!
Nik
