### PR TITLE
Bumpbed pycrypto to fix an issue where RSA.importKey passphrase param do...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ try:
                                    "workerpool>=0.9.2", "Jinja2>=2.7",
                                    "decorator>=3.4.0", "iptools>=0.6.1",
                                    "optcomplete>=1.2-devel",
-                                   "pycrypto >= 2.1, != 2.4"],
+                                   "pycrypto >= 2.6.1"],
                  include_package_data=True,
                  entry_points=dict(console_scripts=console_scripts),
                  zip_safe=False)


### PR DESCRIPTION
...esn't exist

I had this issue which was resolved by updating pycrypt to 2.6.1.

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/cli.py", line 274, in main
    sc.execute(args)
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/commands/loadbalance.py", line 132, in execute
    cluster = self.cm.get_cluster(cluster_tag)
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/cluster.py", line 82, in get_cluster
    cl.validator.validate_keypair()
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/cluster.py", line 2361, in validate_keypair
    keyfingerprint = sshutils.get_private_rsa_fingerprint(key_location)
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/sshutils/**init**.py", line 850, in get_private_rsa_fingerpr
int
    passphrase=passphrase, use_pycrypto=True)
  File "/usr/local/lib/python2.7/dist-packages/StarCluster-0.9999-py2.7.egg/starcluster/sshutils/**init**.py", line 807, in get_rsa_key
    key = RSA.importKey(key_fobj, passphrase=passphrase)
TypeError: importKey() got an unexpected keyword argument 'passphrase'
!!! ERROR - Oops! Looks like you've found a bug in StarCluster

!!! ERROR - Crash report written to: /root/.starcluster/logs/crash-report-4152.txt
!!! ERROR - Please remove any sensitive data from the crash report
!!! ERROR - and submit it to starcluster@mit.edu
