### PR TITLE
Fix crash in get_all_stats() if arr is empty

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -335,8 +335,12 @@ class SGEStats(object):
         bits.append(self.avg_wait_time())
         #last field is array of loads for hosts
         arr = self.get_loads()
-        load_sum = float(reduce(self._add, arr))
-        avg_load = load_sum / len(arr)
+        # arr may be empty if there are no exec hosts
+        if arr:
+            load_sum = float(reduce(self._add, arr))
+            avg_load = load_sum / len(arr)
+        else:
+            avg_load = 0.0
         bits.append(avg_load)
         return bits
 


### PR DESCRIPTION
Should fix jtriley/StarCluster#339.
