### PR TITLE
hadoop: tune max {map,reduce} tasks to num CPUs available

### DIFF
--- a/starcluster/plugins/hadoop.py
+++ b/starcluster/plugins/hadoop.py
@@ -162,9 +162,15 @@ class Hadoop(clustersetup.ClusterSetup):
         mapred_site = node.ssh.remote_file(mapred_site_xml)
         # Hadoop default: 2 maps, 1 reduce
         # AWS EMR uses approx 1 map per proc and .3 reduce per proc
-        map_tasks_max = max(2, int(self.map_to_proc_ratio * node.num_processors()))
-        reduce_tasks_max = max(1, int(self.reduce_to_proc_ratio * node.num_processors()))
-        cfg.update({'map_tasks_max': map_tasks_max, 'reduce_tasks_max': reduce_tasks_max})
+        map_tasks_max = max(
+            2,
+            int(self.map_to_proc_ratio * node.num_processors()))
+        reduce_tasks_max = max(
+            1,
+            int(self.reduce_to_proc_ratio * node.num_processors()))
+        cfg.update({
+            'map_tasks_max': map_tasks_max,
+            'reduce_tasks_max': reduce_tasks_max})
         mapred_site.write(mapred_site_templ % cfg)
         mapred_site.close()
 

--- a/starcluster/plugins/hadoop.py
+++ b/starcluster/plugins/hadoop.py
@@ -164,10 +164,10 @@ class Hadoop(clustersetup.ClusterSetup):
         # AWS EMR uses approx 1 map per proc and .3 reduce per proc
         map_tasks_max = max(
             2,
-            int(self.map_to_proc_ratio * node.num_processors()))
+            int(self.map_to_proc_ratio * node.num_processors))
         reduce_tasks_max = max(
             1,
-            int(self.reduce_to_proc_ratio * node.num_processors()))
+            int(self.reduce_to_proc_ratio * node.num_processors))
         cfg.update({
             'map_tasks_max': map_tasks_max,
             'reduce_tasks_max': reduce_tasks_max})

--- a/starcluster/plugins/hadoop.py
+++ b/starcluster/plugins/hadoop.py
@@ -89,11 +89,11 @@ mapred_site_templ = """\
 </property>
 <property>
   <name>mapred.tasktracker.map.tasks.maximum</name>
-  <value>%(map_tasks_max)s</value>
+  <value>%(map_tasks_max)d</value>
 </property>
 <property>
   <name>mapred.tasktracker.reduce.tasks.maximum</name>
-  <value>%(reduce_tasks_max)s</value>
+  <value>%(reduce_tasks_max)d</value>
 </property>
 </configuration>
 """


### PR DESCRIPTION
This pull request is in response to issue https://github.com/jtriley/StarCluster/issues/115

Hadoop defaults to 2 maps and 1 reduce per node/machine, and starcluster's hadoop plugin uses the default configs.  For large AWS instance types, this configuration leaves much CPU capacity unutilized.  This change creates a custom mapred-site.xml file for each node that configures the mapred.tasktracker.{map,reduce}.tasks.maximum parameters based upon the node's CPU count.  In particular, the change employs a simple heuristic (similar to the one used in EMR's hadoop configs) that assigns 1 map per CPU and ~1/3 reduce per CPU.  The params are included as kwargs to the plugin's constructor, so the user can override this in the plugin's config.

I have manually tested this change using the following (key) starcluster config settings:

[cluster microdumbo]
NODE_INSTANCE_TYPE = c1.xlarge
CLUSTER_SIZE = 2
PLUGINS = hadoop
NODE_IMAGE_ID = ami-765b3e1f

and ran this procedure on the master node:

$ wget http://norvig.com/big.txt
$ pip install mrjob
$ export HADOOP_HOME=/usr/lib/hadoop
$ python /usr/local/lib/python2.7/dist-packages/mrjob/examples/mr_word_freq_count.py -r hadoop big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt big.txt

The job tracker showed 2 nodes, 16 maps, and 4 reduces available, and the job ran up to 16 map tasks in parallel, as desired.  The output looked correct.
