### PR TITLE
Add support for new i2 instance family

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -132,6 +132,10 @@ INSTANCE_TYPES = {
     'c3.2xlarge': ['x86_64'],
     'c3.4xlarge': ['x86_64'],
     'c3.8xlarge': ['x86_64'],
+    'i2.xlarge': ['x86_64'],
+    'i2.2xlarge': ['x86_64'],
+    'i2.4xlarge': ['x86_64'],
+    'i2.8xlarge': ['x86_64'],
 }
 
 MICRO_INSTANCE_TYPES = ['t1.micro']
@@ -151,13 +155,15 @@ HI_STORAGE_TYPES = ['hs1.8xlarge']
 M3_COMPUTE_TYPES = ['c3.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge',
                     'c3.8xlarge']
 
+I2_STORAGE_TYPES = ['i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge']
+
 CLUSTER_TYPES = CLUSTER_COMPUTE_TYPES + CLUSTER_GPU_TYPES + CLUSTER_HIMEM_TYPES
 
 HVM_TYPES = (CLUSTER_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES +
-             M3_COMPUTE_TYPES)
+             M3_COMPUTE_TYPES + I2_STORAGE_TYPES)
 
 PLACEMENT_GROUP_TYPES = (M3_COMPUTE_TYPES + CLUSTER_TYPES + HI_IO_TYPES +
-                         HI_STORAGE_TYPES)
+                         HI_STORAGE_TYPES + I2_STORAGE_TYPES)
 
 CLUSTER_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1']
 


### PR DESCRIPTION
Support for the new i2 instance family -- we can add them to the HI_IO_TYPES, but i2 supports enhanced networking, so a new type "I2_STORAGE_TYPES" is added.
