### PR TITLE
fix (VPC-only?) bug when ssh permissions conflict with default open-ssh-to-world step of cluster setup

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -656,9 +656,11 @@ class Cluster(object):
             desc = 'StarCluster-%s' % static.VERSION.replace('.', '_')
             if self.vpc_id:
                 desc += ' VPC'
+            # Don't open SSH if we'll only re-define permissions for it later
+            perms_has_ssh = 'ssh' in self.permissions
             sg = self.ec2.create_group(self._security_group,
                                        description=desc,
-                                       auth_ssh=True,
+                                       auth_ssh=perms_has_ssh,
                                        auth_group_traffic=True,
                                        vpc_id=self.vpc_id)
             self._add_tags_to_sg(sg)


### PR DESCRIPTION
I recently got a new AWS account which is now tied to VPC services. (As Amazon notes, all new accounts going forward will only be able to use VPC and not EC2 Classic).  For whatever reason, my use of security group permissions causes starcluster to crash using this new account.

My config contains a rule to restrict SSH to a specific cidr:
[permission ssh]
PROTOCOL = tcp
FROM_PORT = 22
TO_PORT = 22
CIDR_IP = XXX.XXX.XXX.XXX/0

When I start a cluster with this config and the new VPC-only account, I get an error about duplicate permissions:

!!! ERROR - InvalidPermission.Duplicate: the specified rule "peer: 0.0.0.0/0, TCP, from port: 22, to port: 22, ALLOW" already exists

I believe the error is because starcluster opens SSH to the world by default with creating a security group, and for whatever reason my new VPC-only account errors out because my ssh permission spec overlaps with the rule that starcluster sets up by default.  I've tried monkeying with my default security group in the EC2 console but that doesn't seem to help.

What works is making starcluster simply not open SSH to the world if there are permissions for ssh set up later.  The below patch seems to fix my bug, though I note that _add_permissions_to_sg() seems to do something similar to revoke world ssh.... let me know if you see a cleaner way to fix this bug and I'll change my patch.
