### PR TITLE
Fix doc typo in pypkginstaller

### DIFF
--- a/starcluster/plugins/pypkginstaller.py
+++ b/starcluster/plugins/pypkginstaller.py
@@ -32,7 +32,7 @@ and the latest released version of some dependencies::
 
     [plugin ipython-dev]
     setup_class = starcluster.plugins.pypkginstaller.PyPkgInstaller
-    install_cmd = pip install -U %s
+    install_command = pip install -U %s
     packages = pyzmq,
                python-msgpack,
                git+http://github.com/ipython/ipython.git


### PR DESCRIPTION
The docstring incorrectly provided an example passing an option named `install_cmd`, the installer expects `install_command`
