### PR TITLE
feature: specify VPC subnet in addnode command

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -637,14 +637,14 @@ class Cluster(object):
     @property
     def subnet(self):
         return self.get_subnet(self.subnet_id)
-    
+
     def get_subnet(self, subnet_id=None):
         """Return either default subnet or subnet by the specified id.
            Caches the subnet objects to avoid redundant ec2 lookups"""
         subnet_id = subnet_id or self.subnet_id
         if subnet_id:
             found = self._subnet.get(subnet_id, None)
-            if found == None:
+            if found is None:
                 found = self.ec2.get_subnet(subnet_id)
                 self._subnet[subnet_id] = found
         return found
@@ -957,7 +957,7 @@ class Cluster(object):
                       placement=zone or getattr(self.zone, 'name', None),
                       user_data=user_data,
                       placement_group=placement_group)
-        
+
         subnet_id = subnet_id or self.subnet_id
         if subnet_id:
             netif = self.ec2.get_network_spec(
@@ -967,7 +967,7 @@ class Cluster(object):
                 network_interfaces=self.ec2.get_network_collection(netif))
         else:
             kwargs.update(security_groups=[cluster_sg])
-            
+
         resvs = []
         if spot_bid:
             security_group_id = self.cluster_group.id

--- a/starcluster/commands/addnode.py
+++ b/starcluster/commands/addnode.py
@@ -97,6 +97,9 @@ class CmdAddNode(ClusterCompleter):
             "-x", "--no-create", dest="no_create", action="store_true",
             default=False, help="do not launch new EC2 instances when "
             "adding nodes (use existing instances instead)")
+        parser.add_option(
+            "-N", "--subnet-id", dest="subnet_id", action="store", type="string",
+            default=None, help=("Launch the new nodes into this VPC subnet"))
 
     def execute(self, args):
         if len(args) != 1:
@@ -125,4 +128,5 @@ class CmdAddNode(ClusterCompleter):
                           image_id=self.opts.image_id,
                           instance_type=self.opts.instance_type,
                           zone=self.opts.zone, spot_bid=self.opts.spot_bid,
-                          no_create=self.opts.no_create)
+                          no_create=self.opts.no_create,
+                          subnet_id=self.opts.subnet_id)

--- a/starcluster/commands/addnode.py
+++ b/starcluster/commands/addnode.py
@@ -98,8 +98,9 @@ class CmdAddNode(ClusterCompleter):
             default=False, help="do not launch new EC2 instances when "
             "adding nodes (use existing instances instead)")
         parser.add_option(
-            "-N", "--subnet-id", dest="subnet_id", action="store", type="string",
-            default=None, help=("Launch the new nodes into this VPC subnet"))
+            "-N", "--subnet-id", dest="subnet_id", action="store",
+            type="string", default=None,
+            help=("Launch the new nodes into this VPC subnet"))
 
     def execute(self, args):
         if len(args) != 1:


### PR DESCRIPTION
This adds a simple fix to the problem of not being able to specify different zones in addnode when using VPC. The problem is that subnets are zone-specific and addnodes did not have an option to change the cluster-wide subnet setting.

This is related to issue #390
