### PR TITLE
Add support for R3 instance types

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -123,6 +123,11 @@ INSTANCE_TYPES = {
     'm3.large': ['x86_64'],
     'm3.xlarge': ['x86_64'],
     'm3.2xlarge': ['x86_64'],
+    'r3.large': ['x86_64'],
+    'r3.xlarge': ['x86_64'],
+    'r3.2xlarge': ['x86_64'],
+    'r3.4xlarge': ['x86_64'],
+    'r3.8xlarge': ['x86_64'],
     'cc1.4xlarge': ['x86_64'],
     'cc2.8xlarge': ['x86_64'],
     'cg1.4xlarge': ['x86_64'],
@@ -151,6 +156,9 @@ CLUSTER_GPU_TYPES = ['g2.2xlarge', 'cg1.4xlarge']
 
 CLUSTER_HIMEM_TYPES = ['cr1.8xlarge']
 
+HIMEM_TYPES = ['r3.large', 'r3.xlarge', 'r3.2xlarge', 'r3.4xlarge',
+               'r3.8xlarge']
+
 HI_IO_TYPES = ['hi1.4xlarge']
 
 HI_STORAGE_TYPES = ['hs1.8xlarge']
@@ -161,7 +169,7 @@ M3_COMPUTE_TYPES = ['c3.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge',
 I2_STORAGE_TYPES = ['i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge']
 
 HVM_ONLY_TYPES = (CLUSTER_COMPUTE_TYPES + CLUSTER_GPU_TYPES +
-                  CLUSTER_HIMEM_TYPES + I2_STORAGE_TYPES)
+                  CLUSTER_HIMEM_TYPES + I2_STORAGE_TYPES + HIMEM_TYPES)
 
 HVM_TYPES = (HVM_ONLY_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES +
              M3_COMPUTE_TYPES)


### PR DESCRIPTION
This addresses https://github.com/jtriley/StarCluster/issues/392 

I added classification as HIMEM_TYPES, as they are not cluster compute instances, and are set to replace the M2 types. 

They are also HVM only types, which makes them somewhat special. 

Let me know if this classification is inaccurate or there are any other changes required. I would love to see this merged so I can stop using a private build :-)
