### PR TITLE
Fix get/put when using dns_prefix

### DIFF
--- a/starcluster/commands/get.py
+++ b/starcluster/commands/get.py
@@ -63,18 +63,18 @@ class CmdGet(ClusterCompleter):
             node = cl.get_node(self.opts.node)
         except exception.InstanceDoesNotExist as ide:
             if self.opts.node == "master":
-                #may have happened because master node is clustername-master
-                #i.e. dns_prefix = True in config
-                #lets check
+                # may have happened because master node is clustername-master
+                # i.e. dns_prefix = True in config
+                # lets check
                 try:
-                    node = cl.get_node('%s-%s' % (ctag, self.opts.node) )
+                    node = cl.get_node('%s-%s' % (ctag, self.opts.node))
                 except exception.InstanceDoesNotExist as ide2:
-                    #k, master is just not there, raise original error
+                    # k, master is just not there, raise original error
                     log.debug("Neither master nor %s-%s exist." % (ctag, 
                         self.opts.node))
-                    raise( ide )
+                    raise(ide)
             else:
-                #node name was provided
+                # node name was provided
                 raise
         if self.opts.user:
             node.ssh.switch_user(self.opts.user)

--- a/starcluster/commands/get.py
+++ b/starcluster/commands/get.py
@@ -70,8 +70,7 @@ class CmdGet(ClusterCompleter):
                     node = cl.get_node('%s-%s' % (ctag, self.opts.node))
                 except exception.InstanceDoesNotExist as ide2:
                     # k, master is just not there, raise original error
-                    log.debug("Neither master nor %s-%s exist." % (ctag, 
-                        self.opts.node))
+                    log.debug("Neither master nor %s-%s exist." % (ctag, self.opts.node))
                     raise(ide)
             else:
                 # node name was provided

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -68,18 +68,18 @@ class CmdPut(ClusterCompleter):
             node = cl.get_node(self.opts.node)
         except exception.InstanceDoesNotExist as ide:
             if self.opts.node == "master":
-                #may have happened because master node is clustername-master
-                #i.e. dns_prefix = True in config
-                #lets check
+                # may have happened because master node is clustername-master
+                # i.e. dns_prefix = True in config
+                # lets check
                 try:
-                    node = cl.get_node('%s-%s' % (ctag, self.opts.node) )
+                    node = cl.get_node('%s-%s' % (ctag, self.opts.node))
                 except exception.InstanceDoesNotExist as ide2:
                     #k, master is just not there, raise original error
                     log.debug("Neither master nor %s-%s exist." % (ctag, 
                         self.opts.node))
-                    raise( ide )
+                    raise(ide)
             else:
-                #node name was provided
+                # node name was provided
                 raise
 
         if self.opts.user:

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -75,8 +75,7 @@ class CmdPut(ClusterCompleter):
                     node = cl.get_node('%s-%s' % (ctag, self.opts.node))
                 except exception.InstanceDoesNotExist as ide2:
                     #k, master is just not there, raise original error
-                    log.debug("Neither master nor %s-%s exist." % (ctag, 
-                        self.opts.node))
+                    log.debug("Neither master nor %s-%s exist." % (ctag, self.opts.node))
                     raise(ide)
             else:
                 # node name was provided


### PR DESCRIPTION
When a cluster is started with dns_prefix=True, the defaults in get/put still only look for master, not <dns_prefix>-master.

i.e. you get
$starcluster get mycluster /path/to/my/file .
StarCluster - (http://star.mit.edu/cluster) (v. 0.95.3)
...
!!! ERROR - node 'master' does not exist

Which can be easily handled with
$starcluster get mycluster -n mycluster-master  /path/to/my/file  .

but this fix is simple enough that I thought I'd send it.
