### PR TITLE
Allows saving the config to master:/etc/master

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -609,8 +609,9 @@ class Cluster(object):
                     master = self.master_node
                 else:
                     raise
-            if load_plugins:
-                self.plugins = self.load_plugins(master.get_plugins())
+            if load_plugins and self.plugins is None:
+                self.plugins = self.load_plugins(
+                    master.get_plugins(self.plugins_order))
             if load_volumes:
                 self.volumes = master.get_volumes()
         except exception.PluginError:
@@ -776,7 +777,7 @@ class Cluster(object):
         config.close()
         master = self.master_node
         self.plugins = self.load_plugins(
-            master.get_plugins(self.plugins_order))
+            master.get_plugins(self.plugins_order, loaded_config["plugins"]))
         self.validate()
 
     @property

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -22,6 +22,7 @@ import string
 import pprint
 import warnings
 import datetime
+import json
 
 import iptools
 
@@ -62,6 +63,11 @@ class ClusterManager(managers.Manager):
                 group = self.ec2.get_security_group(clname)
             cl = Cluster(ec2_conn=self.ec2, cluster_tag=cltag,
                          cluster_group=group)
+
+            # Useful when config is on master node
+            cl.key_location = \
+                self.cfg.get_key(cl.master_node.key_name).get('key_location')
+
             if load_receipt:
                 cl.load_receipt(load_plugins=load_plugins,
                                 load_volumes=load_volumes)
@@ -412,6 +418,8 @@ class Cluster(object):
                  disable_cloudinit=False,
                  subnet_id=None,
                  public_ips=None,
+                 plugins_order=[],
+                 config_on_master=False,
                  **kwargs):
         # update class vars with given vars
         _vars = locals().copy()
@@ -587,6 +595,8 @@ class Cluster(object):
                 sep = '*' * 60
                 log.warn('\n'.join([sep, msg, sep]), extra={'__textwrap__': 1})
             self.update(self._get_settings_from_tags())
+            if self.config_on_master:
+                self._load_config_from_master()
             if not (load_plugins or load_volumes):
                 return True
             try:
@@ -686,9 +696,10 @@ class Cluster(object):
             if tag not in sg.tags:
                 sg.add_tag(tag, chunk)
 
-    def _add_tags_to_sg(self, sg):
-        if static.VERSION_TAG not in sg.tags:
-            sg.add_tag(static.VERSION_TAG, str(static.VERSION))
+    def _get_settings(self):
+        """
+        The settings to save
+        """
         core_settings = dict(cluster_size=self.cluster_size,
                              master_image_id=self.master_image_id,
                              master_instance_type=self.master_instance_type,
@@ -699,16 +710,30 @@ class Cluster(object):
                              subnet_id=self.subnet_id,
                              public_ips=self.public_ips,
                              disable_queue=self.disable_queue,
-                             disable_cloudinit=self.disable_cloudinit)
+                             disable_cloudinit=self.disable_cloudinit,
+                             plugins_order=self.plugins_order)
         user_settings = dict(cluster_user=self.cluster_user,
                              cluster_shell=self.cluster_shell,
                              keyname=self.keyname, spot_bid=self.spot_bid)
-        core = utils.dump_compress_encode(core_settings, use_json=True,
-                                          chunk_size=static.MAX_TAG_LEN)
-        self._add_chunked_tags(sg, core, static.CORE_TAG)
-        user = utils.dump_compress_encode(user_settings, use_json=True,
-                                          chunk_size=static.MAX_TAG_LEN)
-        self._add_chunked_tags(sg, user, static.USER_TAG)
+        return core_settings, user_settings
+
+    def _add_tags_to_sg(self, sg):
+        if static.VERSION_TAG not in sg.tags:
+            sg.add_tag(static.VERSION_TAG, str(static.VERSION))
+        if self.config_on_master:
+            # the only info we store is the fact that config is on master
+            core = utils.dump_compress_encode(
+                dict(config_on_master=self.config_on_master),
+                use_json=True, chunk_size=static.MAX_TAG_LEN)
+            self._add_chunked_tags(sg, core, static.CORE_TAG)
+        else:
+            core_settings, user_settings = self._get_settings()
+            core = utils.dump_compress_encode(core_settings, use_json=True,
+                                              chunk_size=static.MAX_TAG_LEN)
+            self._add_chunked_tags(sg, core, static.CORE_TAG)
+            user = utils.dump_compress_encode(user_settings, use_json=True,
+                                              chunk_size=static.MAX_TAG_LEN)
+            self._add_chunked_tags(sg, user, static.USER_TAG)
 
     def _load_chunked_tags(self, sg, base_tag_name):
         tags = [i for i in sg.tags if i.startswith(base_tag_name)]
@@ -724,6 +749,34 @@ class Cluster(object):
         if static.USER_TAG in sg.tags:
             cluster.update(self._load_chunked_tags(sg, static.USER_TAG))
         return cluster
+
+    def save_config_on_master(self):
+        """
+        Vanilla Improvements function - save the config on the master node.
+        For cluster saving their config on the master node rather than in
+        the security group tags. No more chunk/hashing/splitting headaches.
+        """
+        settings, user_settings = self._get_settings()
+        settings.update(user_settings)
+        settings["plugins"] = self._plugins
+        config = self.master_node.ssh.remote_file(static.MASTER_CFG_FILE, 'wt')
+        json.dump(settings, config, indent=4, separators=(',', ': '),
+                  sort_keys=True)
+        config.close()
+
+    def _load_config_from_master(self):
+        """
+        Vanilla Improvements function - loads the config on the master node.
+        """
+        config = self.master_node.ssh.remote_file(static.MASTER_CFG_FILE, 'rt')
+        loaded_config = json.load(config)
+        self.plugins_order = loaded_config["plugins"]
+        self.update(loaded_config)
+        config.close()
+        master = self.master_node
+        self.plugins = self.load_plugins(
+            master.get_plugins(self.plugins_order))
+        self.validate()
 
     @property
     def placement_group(self):

--- a/starcluster/commands/start.py
+++ b/starcluster/commands/start.py
@@ -180,6 +180,10 @@ class CmdStart(ClusterCompleter):
         parser.add_option("-N", "--subnet-id", dest="subnet_id",
                           action="store", type="string",
                           help=("Launch cluster into a VPC subnet"))
+        parser.add_option("--config-on-master", default=False,
+                          action='store_true', help="Store the config on the "
+                          "master node rather than into the security group "
+                          "tags")
 
     def execute(self, args):
         if len(args) != 1:
@@ -203,9 +207,16 @@ class CmdStart(ClusterCompleter):
         validate = self.opts.validate
         validate_running = self.opts.no_create
         validate_only = self.opts.validate_only
+        config_on_master = self.opts.config_on_master
+
         if scluster:
-            scluster = self.cm.get_cluster(tag, group=scluster)
-            validate_running = True
+            if config_on_master:
+                scluster = self.cm.get_cluster(tag, group=scluster,
+                                               load_receipt=False)
+                validate_running = False
+            else:
+                scluster = self.cm.get_cluster(tag, group=scluster)
+                validate_running = True
         else:
             template = self.opts.cluster_template
             if not template:
@@ -238,10 +249,22 @@ class CmdStart(ClusterCompleter):
                 self.warn_experimental(msg, num_secs=5)
         if self.opts.dns_prefix:
             scluster.dns_prefix = tag
+        if config_on_master:
+            scluster.config_on_master = True
+            if self.opts.no_create:
+                validate = False
+                log.warning("Cannot start a cluster when its config is "
+                            "stored on the master node using StarCluster. "
+                            "You should start it manually and then use "
+                            "the recovery options.")
+                return
         try:
             scluster.start(create=create, create_only=create_only,
                            validate=validate, validate_only=validate_only,
                            validate_running=validate_running)
+            if self.opts.config_on_master and create:
+                log.info("Saving config on master node")
+                scluster.save_config_on_master()
         except KeyboardInterrupt:
             if validate_only:
                 raise

--- a/starcluster/commands/start.py
+++ b/starcluster/commands/start.py
@@ -261,10 +261,8 @@ class CmdStart(ClusterCompleter):
         try:
             scluster.start(create=create, create_only=create_only,
                            validate=validate, validate_only=validate_only,
-                           validate_running=validate_running)
-            if self.opts.config_on_master and create:
-                log.info("Saving config on master node")
-                scluster.save_config_on_master()
+                           validate_running=validate_running,
+                           save_config_on_master=self.opts.config_on_master)
         except KeyboardInterrupt:
             if validate_only:
                 raise

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -154,10 +154,28 @@ class Node(object):
             self._alias = alias
         return self._alias
 
-    def get_plugins(self):
+    def get_plugins_org_metadata(self):
         plugstxt = self.user_data.get(static.UD_PLUGINS_FNAME)
         payload = plugstxt.split('\n', 2)[2]
-        plugins_metadata = utils.decode_uncompress_load(payload)
+        return utils.decode_uncompress_load(payload)
+
+    def get_plugins_full_metadata(self, order):
+        plugins_metadata = self.get_plugins_org_metadata()
+        sg = self.parent_cluster
+        if "@sc-plugins" in sg.tags:
+            stored_diff = utils.decode_uncompress_load(
+                sg.tags["@sc-plugins"])
+            plugins_metadata_json = config.plugins_config_stored_to_json(
+                plugins_metadata)
+            config.apply_json_diff(plugins_metadata_json, stored_diff)
+            plugins_metadata = config.plugins_config_json_to_stored(
+                plugins_metadata_json,
+                order)
+        return plugins_metadata
+
+    def get_plugins(self, order, plugins_metadata=None):
+        if plugins_metadata is None:
+            plugins_metadata = self.get_plugins_full_metadata(order)
         plugs = []
         for klass, args, kwargs in plugins_metadata:
             mod_path, klass_name = klass.rsplit('.', 1)

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -292,4 +292,4 @@ CLUSTER_SETTINGS = {
     'dns_prefix': (bool, False, False, None, None),
 }
 
-MASTER_CFG_FILE = '/etc/starcluster' # vanilla improvements
+MASTER_CFG_FILE = '/etc/starcluster'

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -291,3 +291,5 @@ CLUSTER_SETTINGS = {
     'disable_cloudinit': (bool, False, False, None, None),
     'dns_prefix': (bool, False, False, None, None),
 }
+
+MASTER_CFG_FILE = '/etc/starcluster' # vanilla improvements


### PR DESCRIPTION
This is working over my version but I haven't tested it over the core StarCluster version.
I made this PR in order to allow others to see the functionality and grab it if they need it.
- Pros
  - Allows to easily update the config by editing the file.
  - No more obscure config update via compressed/hashed data in metadata/tags and other "obscure" places.
- Cons
  - No longer possible to start a stopped cluster via StarCluster. (This is technically fixable, but not planned at the moment.)
