### PR TITLE
  terminate command fails when nodes are in a VPC

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1468,6 +1468,9 @@ class Cluster(object):
         filters = {'instance.group-name': self._security_group,
                    'instance-state-name': states}
         insts = self.ec2.get_all_instances(filters=filters)
+        filters = {'placement-group-name': self.placement_group.name,
+                   'instance-state-name': states}
+        insts += self.ec2.get_all_instances(filters=filters)
         return len(insts) == 0
 
     def attach_volumes_to_master(self):


### PR DESCRIPTION
Modifies the is_cluster_terminated check to include instances that belong to the placement group

It seems that when a instance is terminated in a VPC the security group is automatically removed
from the instance metadata causing the is_cluster_terminated to return a false positive.
The code will then continue and try to remove the placement group but time out since the
placement group cannot be removed with instances remaining.
