### PR TITLE
Fix to BotoPlugin to switch back to original user.

### DIFF
--- a/starcluster/plugins/boto.py
+++ b/starcluster/plugins/boto.py
@@ -40,6 +40,7 @@ class BotoPlugin(clustersetup.ClusterSetup):
 
     def run(self, nodes, master, user, shell, volumes):
         mssh = master.ssh
+        orig_user = mssh.get_current_user()
         mssh.switch_user(user)
         botocfg = '/home/%s/.boto' % user
         if not mssh.path_exists(botocfg):
@@ -55,3 +56,4 @@ class BotoPlugin(clustersetup.ClusterSetup):
             mssh.chmod(0400, botocfg)
         else:
             log.warn("AWS credentials already present - skipping install")
+        mssh.switch_user(orig_user)


### PR DESCRIPTION
Fixes #417

If the BotoPlugin were run before other plugins that depend on the user being root, then, permission problems would crop up.
