### PR TITLE
Streaming node add

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1116,6 +1116,10 @@ class Cluster(object):
                                  node=ready_instance, nodes=up_nodes)
             if any([unpropagated_spots, spots,
                     unpropagated_instances, instances]):
+                if ready_instances:
+                    # Nodes were added, that took
+                    # time so we should loop again now
+                    continue
                 time.sleep(interval)
             else:
                 break

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1059,7 +1059,7 @@ class Cluster(object):
 
         interval = self.refresh_interval
         log.info("Waiting for one of the new nodes to be up "
-                "(updating every {}s)".format(interval))
+                 "(updating every {}s)".format(interval))
         while True:
             ready_instances = []
             if spots:
@@ -1091,7 +1091,6 @@ class Cluster(object):
                 time.sleep(interval)
             else:
                 break
-
 
     def remove_node(self, node=None, terminate=True, force=False):
         """

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1116,8 +1116,9 @@ class Cluster(object):
                                  node=ready_instance, nodes=up_nodes)
             if any([unpropagated_spots, spots,
                     unpropagated_instances, instances]):
-                if ready_instances:
-                    # Nodes were added, that took
+                if instances or ready_instances:
+                    # instances means we wait on ssh is_up, no need to sleep
+                    # ready_instances means nodes were added, that took
                     # time so we should loop again now
                     continue
                 time.sleep(interval)

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1073,7 +1073,7 @@ class Cluster(object):
                     unpropagated_spots, spots)
                 if unpropagated_spots:
                     log.info("Still waiting for unpropagated spots:"
-                            + str(unpropagated_spots))
+                             + str(unpropagated_spots))
 
             if spots:
                 instance_ids = []
@@ -1097,7 +1097,7 @@ class Cluster(object):
                     unpropagated_instances, instances)
                 if unpropagated_instances:
                     log.info("Still waiting for unpropagated instances: "
-                            + str(unpropagated_instances))
+                             + str(unpropagated_instances))
 
             if instances:
                 instances = self.get_nodes_or_raise(nodes=instances)

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1101,9 +1101,12 @@ class Cluster(object):
 
             if instances:
                 instances = self.get_nodes_or_raise(nodes=instances)
-                instances = utils.filter_move(
-                    lambda i: i.state != 'running' or not i.is_up(),
-                    instances, ready_instances)
+                ssh_up = self.pool.map(lambda i: i.is_up(), instances)
+                zip_instances = utils.filter_move(
+                    lambda i: i[0].state != 'running' or not i[1],
+                    zip(instances, ssh_up), ready_instances,
+                    lambda i: i[0])
+                instances = [i[0] for i in zip_instances]
                 if instances:
                     log.info("Still waiting for instances: " + str(instances))
             for ready_instance in ready_instances:

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -880,11 +880,14 @@ class Cluster(object):
             filters['launch.group-id'] = group_id
         return self.ec2.get_all_spot_requests(filters=filters)
 
-    def get_spot_requests_or_raise(self):
-        spots = self.spot_requests
-        if not spots:
+    def get_spot_requests_or_raise(self, spots):
+        _spots = self.spot_requests
+        if not _spots:
             raise exception.NoClusterSpotRequests
-        return spots
+        if spots:
+            spots_ids = [s.id for s in spots]
+            _spots = filter(lambda s: s.id in spots_ids, _spots)
+        return _spots
 
     def create_node(self, alias, image_id=None, instance_type=None, zone=None,
                     placement_group=None, spot_bid=None, force_flat=False):
@@ -1386,7 +1389,7 @@ class Cluster(object):
                 pbar.update(len(active_spots))
                 if not pbar.finished:
                     time.sleep(self.refresh_interval)
-                    spots = self.get_spot_requests_or_raise()
+                    spots = self.get_spot_requests_or_raise(spots)
             pbar.reset()
         self.ec2.wait_for_propagation(
             instances=[s.instance_id for s in spots])

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -649,3 +649,14 @@ def get_spinner(msg):
     log.info(msg, extra=dict(__nonewline__=True))
     s.start()
     return s
+
+def filter_move(keep_fct, in_, out, extract_fct=None):
+    def _filter(item):
+        if keep_fct(item):
+            return True
+        if extract_fct:
+            out.append(extract_fct(item))
+        else:
+            out.append(item)
+        return False
+    return filter(_filter, in_)

--- a/starcluster/utils.py
+++ b/starcluster/utils.py
@@ -650,6 +650,7 @@ def get_spinner(msg):
     s.start()
     return s
 
+
 def filter_move(keep_fct, in_, out, extract_fct=None):
     def _filter(item):
         if keep_fct(item):


### PR DESCRIPTION
Rather than waiting for all spot instances and then for all instances ssh to be up prior to starting adding the nodes to a cluster, adds the node as they come ready.
- May be useful when adding many nodes at once. The greater the amount of added nodes is, the greater the probability this will be beneficial is.
- No difference when adding a single node.

Note: This is based on 2 bug fixes pull requests, namely https://github.com/jtriley/StarCluster/pull/433 and https://github.com/jtriley/StarCluster/pull/433
