### PR TITLE
Add support for Ubuntu trusty (and other newer distribution releases)

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -90,6 +90,7 @@ class Node(object):
         self._groups = None
         self._ssh = None
         self._num_procs = None
+        self._rpcbind_service_name = None
         self._memory = None
         self._user_data = None
 
@@ -227,6 +228,22 @@ class Node(object):
                 self.ssh.execute(
                     'cat /proc/cpuinfo | grep processor | wc -l')[0])
         return self._num_procs
+
+    @property
+    def rpcbind_service_name(self):
+        """
+        Determine whether the system uses 'rpcbind' to name the RPC
+        service, or whether it uses the legacy 'portmap' name.
+        """
+        if not self._rpcbind_service_name:
+            try:
+                self.ssh.execute(
+                    'test -e /etc/init.d/rpcbind',
+                    raise_on_failure=True)
+                self._rpcbind_service_name = 'rpcbind'
+            except exception.SSHError:
+                self._rpcbind_service_name = 'portmap'
+        return self._rpcbind_service_name
 
     @property
     def memory(self):
@@ -701,7 +718,7 @@ class Node(object):
 
     def start_nfs_server(self):
         log.info("Starting NFS server on %s" % self.alias)
-        self.ssh.execute('service portmap start', ignore_exit_status=True)
+        self.ssh.execute('service %s start' % self.rpcbind_service_name, ignore_exit_status=True)
         self.ssh.execute('mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs/',
                          ignore_exit_status=True)
         EXPORTSD = '/etc/exports.d'
@@ -727,7 +744,8 @@ class Node(object):
         server_node - remote server node that is sharing the remote_paths
         remote_paths - list of remote paths to mount from server_node
         """
-        self.ssh.execute('service portmap start')
+        self.ssh.execute('service %s start' % self.rpcbind_service_name,
+                ignore_exit_status=True)
         # TODO: move this fix for xterm somewhere else
         self.ssh.execute('mount -t devpts none /dev/pts',
                          ignore_exit_status=True)

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -718,7 +718,9 @@ class Node(object):
 
     def start_nfs_server(self):
         log.info("Starting NFS server on %s" % self.alias)
-        self.ssh.execute('service %s start' % self.rpcbind_service_name, ignore_exit_status=True)
+        self.ssh.execute(
+            'service %s start' % self.rpcbind_service_name,
+            ignore_exit_status=True)
         self.ssh.execute('mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs/',
                          ignore_exit_status=True)
         EXPORTSD = '/etc/exports.d'
@@ -744,8 +746,9 @@ class Node(object):
         server_node - remote server node that is sharing the remote_paths
         remote_paths - list of remote paths to mount from server_node
         """
-        self.ssh.execute('service %s start' % self.rpcbind_service_name,
-                ignore_exit_status=True)
+        self.ssh.execute(
+            'service %s start' % self.rpcbind_service_name,
+            ignore_exit_status=True)
         # TODO: move this fix for xterm somewhere else
         self.ssh.execute('mount -t devpts none /dev/pts',
                          ignore_exit_status=True)

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -701,7 +701,7 @@ class Node(object):
 
     def start_nfs_server(self):
         log.info("Starting NFS server on %s" % self.alias)
-        self.ssh.execute('/etc/init.d/portmap start', ignore_exit_status=True)
+        self.ssh.execute('service portmap start', ignore_exit_status=True)
         self.ssh.execute('mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs/',
                          ignore_exit_status=True)
         EXPORTSD = '/etc/exports.d'
@@ -715,7 +715,7 @@ class Node(object):
         self.ssh.execute("mkdir -p %s" % DUMMY_EXPORT_DIR)
         with self.ssh.remote_file(DUMMY_EXPORT_FILE, 'w') as dummyf:
             dummyf.write(DUMMY_EXPORT_LINE)
-        self.ssh.execute('/etc/init.d/nfs start')
+        self.ssh.execute('service nfs start')
         self.ssh.execute('rm -f %s' % DUMMY_EXPORT_FILE)
         self.ssh.execute('rm -rf %s' % DUMMY_EXPORT_DIR)
         self.ssh.execute('exportfs -fra')
@@ -727,7 +727,7 @@ class Node(object):
         server_node - remote server node that is sharing the remote_paths
         remote_paths - list of remote paths to mount from server_node
         """
-        self.ssh.execute('/etc/init.d/portmap start')
+        self.ssh.execute('service portmap start')
         # TODO: move this fix for xterm somewhere else
         self.ssh.execute('mount -t devpts none /dev/pts',
                          ignore_exit_status=True)

--- a/starcluster/plugins/condor.py
+++ b/starcluster/plugins/condor.py
@@ -40,7 +40,7 @@ class CondorPlugin(clustersetup.DefaultClusterSetup):
         config_vals = ['$(condor_config_val %s)' % var for var in config_vars]
         node.ssh.execute('mkdir -p %s' % ' '.join(config_vals))
         node.ssh.execute('chown -R condor:condor %s' % ' '.join(config_vals))
-        node.ssh.execute('/etc/init.d/condor start')
+        node.ssh.execute('service condor start')
 
     def _setup_condor(self, master=None, nodes=None):
         log.info("Setting up Condor grid")

--- a/starcluster/plugins/hadoop.py
+++ b/starcluster/plugins/hadoop.py
@@ -279,23 +279,23 @@ class Hadoop(clustersetup.ClusterSetup):
         node.ssh.execute("chmod -R %s %s" % (permission, path))
 
     def _start_datanode(self, node):
-        node.ssh.execute('/etc/init.d/hadoop-0.20-datanode restart')
+        node.ssh.execute('service hadoop-0.20-datanode restart')
 
     def _start_tasktracker(self, node):
-        node.ssh.execute('/etc/init.d/hadoop-0.20-tasktracker restart')
+        node.ssh.execute('service hadoop-0.20-tasktracker restart')
 
     def _start_hadoop(self, master, nodes):
         log.info("Starting namenode...")
-        master.ssh.execute('/etc/init.d/hadoop-0.20-namenode restart')
+        master.ssh.execute('service hadoop-0.20-namenode restart')
         log.info("Starting secondary namenode...")
-        master.ssh.execute('/etc/init.d/hadoop-0.20-secondarynamenode restart')
+        master.ssh.execute('service hadoop-0.20-secondarynamenode restart')
         log.info("Starting datanode on all nodes...")
         for node in nodes:
             self.pool.simple_job(self._start_datanode, (node,),
                                  jobid=node.alias)
         self.pool.wait()
         log.info("Starting jobtracker...")
-        master.ssh.execute('/etc/init.d/hadoop-0.20-jobtracker restart')
+        master.ssh.execute('service hadoop-0.20-jobtracker restart')
         log.info("Starting tasktracker on all nodes...")
         for node in nodes:
             self.pool.simple_job(self._start_tasktracker, (node,),

--- a/starcluster/plugins/mysql.py
+++ b/starcluster/plugins/mysql.py
@@ -191,10 +191,10 @@ class MysqlCluster(DefaultClusterSetup):
     2. chown -R mysql:mysql /var/lib/mysql-cluster/
     3. generate ndb-mgmd for master
     4. generate my.cnf for data nodes
-    5. /etc/init.d/mysql-ndb-mgm restart on master
+    5. service mysql-ndb-mgm restart on master
     6. pkill -9 mysql on data nodes
-    7. /etc/init.d/mysql start on data nodes
-    8. /etc/init.d/mysql-ndb restart on data nodes
+    7. service mysql start on data nodes
+    8. service mysql-ndb restart on data nodes
 
     Correction to above, do this:
     1. define plugin section in config named mysql
@@ -279,19 +279,19 @@ class MysqlCluster(DefaultClusterSetup):
         self.pool.wait(len(nodes))
         # Restart mysql-ndb-mgm on master
         log.info('Restarting mysql-ndb-mgm on master node...')
-        mconn.execute('/etc/init.d/mysql-ndb-mgm restart')
+        mconn.execute('service mysql-ndb-mgm restart')
         # Start mysqld-ndb on data nodes
         log.info('Restarting mysql-ndb on all data nodes...')
         for node in self.data_nodes:
             self.pool.simple_job(node.ssh.execute,
-                                 ('/etc/init.d/mysql-ndb restart'),
+                                 ('service mysql-ndb restart'),
                                  jobid=node.alias)
         self.pool.wait(len(self.data_nodes))
         # Start mysql on query nodes
         log.info('Starting mysql on all query nodes')
         for node in self.query_nodes:
             self.pool.simple_job(node.ssh.execute,
-                                 ('/etc/init.d/mysql restart'),
+                                 ('service mysql restart'),
                                  dict(ignore_exit_status=True),
                                  jobid=node.alias)
         self.pool.wait(len(self.query_nodes))


### PR DESCRIPTION
Replace all direct calls to /etc/init.d with calls through the standard 'service' command.

Newer distributions call the 'portmap' service 'rpcbind'. Detect which is installed and call the appropriate service.
