### PR TITLE
added slots_per_host option to load_balance

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -410,7 +410,8 @@ class SGELoadBalancer(LoadBalancer):
     def __init__(self, interval=60, max_nodes=None, wait_time=900,
                  add_pi=1, kill_after=45, stab=180, lookback_win=3,
                  min_nodes=None, kill_cluster=False, plot_stats=False,
-                 plot_output_dir=None, dump_stats=False, stats_file=None):
+                 plot_output_dir=None, dump_stats=False, stats_file=None,
+                 slots_per_host=None):
         self._cluster = None
         self._keep_polling = True
         self._visualizer = None
@@ -429,6 +430,7 @@ class SGELoadBalancer(LoadBalancer):
         self.stats_file = stats_file
         self.plot_stats = plot_stats
         self.plot_output_dir = plot_output_dir
+        self.slots_per_host = slots_per_host
         if plot_stats:
             assert self.visualizer is not None
 
@@ -684,7 +686,7 @@ class SGELoadBalancer(LoadBalancer):
         running_jobs = self.stat.get_running_jobs()
         used_slots = sum([int(j['slots']) for j in running_jobs])
         qw_slots = sum([int(j['slots']) for j in queued_jobs])
-        slots_per_host = self.stat.slots_per_host()
+        slots_per_host = self.slots_per_host or self.stat.slots_per_host()
         avail_slots = total_slots - used_slots
         need_to_add = 0
         if num_nodes < self.min_nodes:

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -103,6 +103,10 @@ class CmdLoadBalance(ClusterCompleter):
         parser.add_option("-K", "--kill-cluster", dest="kill_cluster",
                           action="store_true", default=False,
                           help="Terminate the cluster when the queue is empty")
+        parser.add_option("--slots_per_host", dest="slots_per_host",
+                          action="callback", type="int", default=None,
+                          callback=self._positive_int,
+                          help="slots_per_host in cluster")
 
     def execute(self, args):
         if not self.cfg.globals.enable_experimental:


### PR DESCRIPTION
Can now manually specify the slots_per_host that would be added if the load balancer were to start another node
