### PR TITLE
Don't crash if the connection has an error

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -21,6 +21,7 @@ import stat
 import base64
 import posixpath
 import subprocess
+import socket
 
 from starcluster import utils
 from starcluster import static
@@ -1017,7 +1018,12 @@ class Node(object):
     def is_up(self):
         if self.update() != 'running':
             return False
-        if not self.is_ssh_up():
+        try:
+            if not self.is_ssh_up():
+                return False
+        except socket.error as e:
+            log.warning("Checking if node {} is up encountered exception {}"
+                        .format(self.alias, e), exc_info=True)
             return False
         if self.private_ip_address is None:
             log.debug("instance %s has no private_ip_address" % self.id)


### PR DESCRIPTION
Fixes crahses associated to

```
File "/usr/local/lib/python2.7/dist-packages/paramiko-1.15.1-py2.7.egg/paramiko/transport.py", line 731, in     open_channel
    raise e
error: [Errno 104] Connection reset by peer


!!! ERROR - Oops! Looks like you've found a bug in StarCluster
!!! ERROR - Crash report written to: /home/datacratic/.starcluster/logs/crash-report-9893.txt
!!! ERROR - Please remove any sensitive data from the crash report
!!! ERROR - and submit it to starcluster@mit.edu
```
