### PR TITLE
allow disabling default plugin

### DIFF
--- a/starcluster/commands/start.py
+++ b/starcluster/commands/start.py
@@ -74,6 +74,9 @@ class CmdStart(ClusterCompleter):
         parser.add_option("-q", "--disable-queue", dest="disable_queue",
                           action="store_true", default=None,
                           help="do not configure a queueing system (SGE)")
+        parser.add_option("--disable-default", dest="disable_default",
+                          action="store_true", default=None,
+                          help="do not configure default plugin")
         parser.add_option("-Q", "--enable-queue", dest="disable_queue",
                           action="store_false", default=None,
                           help="configure a queueing system (SGE) (default)")

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -287,6 +287,7 @@ CLUSTER_SETTINGS = {
     'permissions': (list, False, [], None, None),
     'userdata_scripts': (list, False, [], None, __expand_all_in_list),
     'disable_queue': (bool, False, False, None, None),
+    'disable_default': (bool, False, False, None, None),
     'force_spot_master': (bool, False, False, None, None),
     'disable_cloudinit': (bool, False, False, None, None),
     'dns_prefix': (bool, False, False, None, None),


### PR DESCRIPTION
Adds an option, `disable_default`, similar to `disable_queue` that allows disabling the default plugin. This allows the user to explicitly order the default plugin relative to other plugins. This is useful if some set up is required before running the default plugin.

For example I run `starcluster.plugins.pkginstaller.PackageInstaller` first.
