### PR TITLE
specifies that shell commands should be executed always with bash

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -1107,7 +1107,7 @@ class Node(object):
                 command = "'source /etc/profile && %s'" % command
                 ssh_cmd = ' '.join([ssh_cmd, command])
             log.debug("ssh_cmd: %s" % ssh_cmd)
-            return subprocess.call(ssh_cmd, shell=True)
+            return subprocess.call(ssh_cmd, shell=True, executable='/bin/bash')
         else:
             log.debug("Using Pure-Python SSH client")
             if forward_x11:


### PR DESCRIPTION
I had changed the sgeadmin default shell to zsh, which was causing a crash when starting up the ipython notebooks because the script globs for json files and, finding none, zsh a 1 code which kills the script. Bash just hums along and finishes.
