### PR TITLE
change debian pkg URL & key from www.cs.wisc.edu -> research.cs.wisc.edu

### DIFF
--- a/utils/scimage.py
+++ b/utils/scimage.py
@@ -62,7 +62,8 @@ CLOUD_CFG_FILE = '/etc/cloud/cloud.cfg'
 GRID_SCHEDULER_GIT = 'git://github.com/jtriley/gridscheduler.git'
 CLOUDERA_ARCHIVE_KEY = 'http://archive.cloudera.com/debian/archive.key'
 CLOUDERA_APT = 'http://archive.cloudera.com/debian maverick-cdh3u5 contrib'
-CONDOR_APT = 'http://www.cs.wisc.edu/condor/debian/development lenny contrib'
+CONDOR_ARCHIVE_KEY = 'http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key'
+CONDOR_APT = 'http://research.cs.wisc.edu/htcondor/debian/stable lenny contrib'
 NUMPY_SCIPY_SITE_CFG = """\
 [DEFAULT]
 library_dirs = /usr/lib
@@ -267,6 +268,7 @@ def configure_apt_sources():
     srcfile.close()
     run_command('gpg --keyserver keyserver.ubuntu.com --recv-keys 0F932C9C')
     run_command('curl -s %s | sudo apt-key add -' % CLOUDERA_ARCHIVE_KEY)
+    run_command('curl -s %s | sudo apt-key add -' % CONDOR_ARCHIVE_KEY)
     apt_install('debian-archive-keyring')
 
 

--- a/utils/scimage_11_10.py
+++ b/utils/scimage_11_10.py
@@ -58,7 +58,8 @@ CLOUD_CFG_FILE = '/etc/cloud/cloud.cfg'
 GRID_SCHEDULER_GIT = 'git://github.com/jtriley/gridscheduler.git'
 CLOUDERA_ARCHIVE_KEY = 'http://archive.cloudera.com/debian/archive.key'
 CLOUDERA_APT = 'http://archive.cloudera.com/debian maverick-cdh3 contrib'
-CONDOR_APT = 'http://www.cs.wisc.edu/condor/debian/development lenny contrib'
+CONDOR_ARCHIVE_KEY = 'http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key'
+CONDOR_APT = 'http://research.cs.wisc.edu/htcondor/debian/stable lenny contrib'
 NUMPY_SCIPY_SITE_CFG = """\
 [DEFAULT]
 library_dirs = /usr/lib
@@ -241,6 +242,7 @@ def configure_apt_sources():
     srcfile.close()
     run_command('gpg --keyserver keyserver.ubuntu.com --recv-keys 0F932C9C')
     run_command('curl -s %s | sudo apt-key add -' % CLOUDERA_ARCHIVE_KEY)
+    run_command('curl -s %s | sudo apt-key add -' % CONDOR_ARCHIVE_KEY)
     apt_install('debian-archive-keyring')
 
 

--- a/utils/scimage_12_04.py
+++ b/utils/scimage_12_04.py
@@ -64,7 +64,8 @@ CLOUD_CFG_FILE = '/etc/cloud/cloud.cfg'
 GRID_SCHEDULER_GIT = 'git://github.com/jtriley/gridscheduler.git'
 CLOUDERA_ARCHIVE_KEY = 'http://archive.cloudera.com/debian/archive.key'
 CLOUDERA_APT = 'http://archive.cloudera.com/debian maverick-cdh3u5 contrib'
-CONDOR_APT = 'http://www.cs.wisc.edu/condor/debian/development lenny contrib'
+CONDOR_ARCHIVE_KEY = 'http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key'
+CONDOR_APT = 'http://research.cs.wisc.edu/htcondor/debian/stable lenny contrib'
 NUMPY_SCIPY_SITE_CFG = """\
 [DEFAULT]
 library_dirs = /usr/lib
@@ -249,6 +250,7 @@ def configure_apt_sources():
     run_command('add-apt-repository ppa:staticfloat/julia-deps -y')
     run_command('gpg --keyserver keyserver.ubuntu.com --recv-keys 0F932C9C')
     run_command('curl -s %s | sudo apt-key add -' % CLOUDERA_ARCHIVE_KEY)
+    run_command('curl -s %s | sudo apt-key add -' % CONDOR_ARCHIVE_KEY)
     apt_install('debian-archive-keyring')
 
 


### PR DESCRIPTION
Without this mod, I was unable to run `apt-get update` w/o an exit status `100`, from the `404` on the http://www.cs.wisc.edu pkg ref w/ the following AMI:

```
ami-02674b47 us-west-1 starcluster-base-ubuntu-12.04-x86_64
```

I wasn't sure which files I needed to hit here, so I hit them all, sans, `utils/scimage_13_04.py`, where **condor** is clearly disabled. This is just a text replacement + educated guess on the public key load. I did these things on the cmdline. I don't have a full dev env setup.
