### PR TITLE
allow icmp firewall rules in starcluster configuration

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -2049,9 +2049,9 @@ class ClusterValidator(validators.Validator):
                     from_port, to_port, reason="integer range required")
             if protocol == 'icmp':
                 if from_port != -1 or to_port != -1:
-                raise exception.InvalidPortRange(
-                    from_port, to_port,
-                    reason="for icmp protocol from_port and to_port must be -1")
+                    raise exception.InvalidPortRange(
+                        from_port, to_port,
+                        reason="for icmp protocol from_port and to_port must be -1")
             else:
                 if from_port < 0 or to_port < 0:
                     raise exception.InvalidPortRange(

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -2047,14 +2047,20 @@ class ClusterValidator(validators.Validator):
             except ValueError:
                 raise exception.InvalidPortRange(
                     from_port, to_port, reason="integer range required")
-            if from_port < 0 or to_port < 0:
+            if protocol == 'icmp':
+                if from_port != -1 or to_port != -1:
                 raise exception.InvalidPortRange(
                     from_port, to_port,
-                    reason="from/to must be positive integers")
-            if from_port > to_port:
-                raise exception.InvalidPortRange(
-                    from_port, to_port,
-                    reason="'from_port' must be <= 'to_port'")
+                    reason="for icmp protocol from_port and to_port must be -1")
+            else:
+                if from_port < 0 or to_port < 0:
+                    raise exception.InvalidPortRange(
+                        from_port, to_port,
+                        reason="from/to must be positive integers")
+                if from_port > to_port:
+                    raise exception.InvalidPortRange(
+                        from_port, to_port,
+                        reason="'from_port' must be <= 'to_port'")
             cidr_ip = permission.get('cidr_ip')
             if not iptools.ipv4.validate_cidr(cidr_ip):
                 raise exception.InvalidCIDRSpecified(cidr_ip)


### PR DESCRIPTION
Boto docs says that rules for icmp protocol must use port=-1
http://boto.readthedocs.org/en/latest/security_groups.html

Now starcluster doesn't allow to do this. This patch should fix it and allow to add a a rule like this in the starcluster configuration:

```
[permission all-icmp-internal]
IP_PROTOCOL = icmp
FROM_PORT = -1
TO_PORT = -1
CIDR_IP = 192.168.1.0/24
```
