### PR TITLE
Support for images with multiple volumes, addressing inconsistent behavior with CreatUsers plugin

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1496,12 +1496,19 @@ class Cluster(object):
         for vol in wait_for_volumes:
             self.ec2.wait_for_volume(vol, state='attached')
 
-    def detach_volumes(self):
+    def detach_volumes(self,external=False):
         """
         Detach all volumes from all nodes
         """
-        for node in self.nodes:
-            node.detach_external_volumes()
+        if external:
+            log.info("Detaching all external volumes")
+            for node in self.nodes:
+                node.detach_external_volumes()
+        else:
+            log.info("Detaching shared volumes only")
+            for node in self.nodes:
+                node.detach_shared_volumes()
+
 
     @print_timing('Restarting cluster')
     def restart_cluster(self, reboot_only=False):
@@ -1553,7 +1560,7 @@ class Cluster(object):
                 log.warn("Cannot run plugins: %s" % e)
             else:
                 raise
-        self.detach_volumes()
+        self.detach_volumes(external=False)
         for node in nodes:
             node.shutdown()
 
@@ -1570,7 +1577,7 @@ class Cluster(object):
                 log.warn("Cannot run plugins: %s" % e)
             else:
                 raise
-        self.detach_volumes()
+        self.detach_volumes(external=True)
         nodes = self.nodes
         for node in nodes:
             node.terminate()

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -258,7 +258,7 @@ class DefaultClusterSetup(ClusterSetup):
         """
         log.info("Configuring passwordless ssh for root")
         master = self._master
-        nodes = nodes or self.nodes
+        nodes = nodes or self._nodes
         master.generate_key_for_user('root', auth_new_key=True,
                                      auth_conn_key=True)
         master.enable_passwordless_ssh('root', nodes)

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -258,7 +258,7 @@ class DefaultClusterSetup(ClusterSetup):
         """
         log.info("Configuring passwordless ssh for root")
         master = self._master
-        nodes = nodes or self._nodes
+        nodes = nodes or self.nodes
         master.generate_key_for_user('root', auth_new_key=True,
                                      auth_conn_key=True)
         master.enable_passwordless_ssh('root', nodes)

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -891,6 +891,19 @@ class Node(object):
             if vol.status not in ['available', 'detaching']:
                 vol.detach()
 
+    def detach_shared_volumes(self):
+        """
+        Detaches all shared volumes (i.e. from the master) returned by self.get_volumes
+        """
+        if self.is_master():
+            block_devs = self.get_volumes().values()
+            for dev in block_devs:
+                vol_id = dev.volume_id
+                vol = self.ec2.get_volume(vol_id)
+                log.info("Detaching volume %s from %s" % (vol.id, self.alias))
+                if vol.status not in ['available', 'detaching']:
+                    vol.detach()
+
     def delete_root_volume(self):
         """
         Detach and destroy EBS root volume (EBS-backed node only)

--- a/starcluster/plugins/users.py
+++ b/starcluster/plugins/users.py
@@ -17,6 +17,7 @@
 
 import os
 import posixpath
+from datetime import datetime
 
 from starcluster import utils
 from starcluster import static
@@ -66,8 +67,10 @@ class CreateUsers(clustersetup.DefaultClusterSetup):
         self._user_shell = user_shell
         self._volumes = volumes
         log.info("Creating %d cluster users" % self._num_users)
+        log.info("Usernames listing %s " % self._usernames)
         newusers = self._get_newusers_batch_file(master, self._usernames,
                                                  user_shell)
+        log.info("newuser_names listing %s " % newusers)
         for node in nodes:
             self.pool.simple_job(node.ssh.execute,
                                  ("echo -n '%s' | newusers" % newusers),
@@ -111,20 +114,25 @@ class CreateUsers(clustersetup.DefaultClusterSetup):
 
     def _get_newusers_batch_file(self, master, usernames, shell,
                                  batch_file=None):
+        bfilecontents = ''
         batch_file = batch_file or self.BATCH_USER_FILE
         if master.ssh.isfile(batch_file):
             bfile = master.ssh.remote_file(batch_file, 'r')
             bfilecontents = bfile.read()
             bfile.close()
-            return bfilecontents
-        bfilecontents = ''
+            # return bfilecontents
         tmpl = "%(username)s:%(password)s:%(uid)d:%(gid)d:"
         tmpl += "Cluster user account %(username)s:"
         tmpl += "/home/%(username)s:%(shell)s\n"
         shpath = master.ssh.which(shell)[0]
         ctx = dict(shell=shpath)
         base_uid, base_gid = self._get_max_unused_user_id()
+        found_newuser = False
         for user in usernames:
+            if user in bfilecontents:
+	        log.info ("Skipping %s user previously created" % user)
+                break	
+            found_newuser = True
             home_folder = '/home/%s' % user
             if master.ssh.path_exists(home_folder):
                 s = master.ssh.stat(home_folder)
@@ -141,9 +149,13 @@ class CreateUsers(clustersetup.DefaultClusterSetup):
         pardir = posixpath.dirname(batch_file)
         if not master.ssh.isdir(pardir):
             master.ssh.makedirs(pardir)
-        bfile = master.ssh.remote_file(batch_file, 'w')
-        bfile.write(bfilecontents)
-        bfile.close()
+        if master.ssh.isfile(batch_file) and found_newuser:
+            d=datetime.now().isoformat('T')
+            master.ssh.rename(batch_file, batch_file+"."+d+".bk")
+        if not master.ssh.isfile(batch_file):
+            bfile = master.ssh.remote_file(batch_file, 'w')
+            bfile.write(bfilecontents)
+            bfile.close()
         return bfilecontents
 
     def on_add_node(self, node, nodes, master, user, user_shell, volumes):

--- a/starcluster/plugins/users.py
+++ b/starcluster/plugins/users.py
@@ -131,7 +131,7 @@ class CreateUsers(clustersetup.DefaultClusterSetup):
         for user in usernames:
             if user in bfilecontents:
 	        log.info ("Skipping %s user previously created" % user)
-                break	
+                continue	
             found_newuser = True
             home_folder = '/home/%s' % user
             if master.ssh.path_exists(home_folder):

--- a/starcluster/sshutils.py
+++ b/starcluster/sshutils.py
@@ -271,6 +271,16 @@ class SSHClient(object):
             if not ignore_failure:
                 raise
 
+    def rename(self, oldpath, newpath, ignore_failure=False):
+        """
+        Rename a file on the remote machine
+        """
+        try:
+            return self.sftp.rename(oldpath,newpath)
+        except IOError:
+            if not ignore_failure:
+                raise
+
     def get_remote_file_lines(self, remote_file, regex=None, matching=True):
         """
         Returns list of lines in a remote_file


### PR DESCRIPTION
We've had to create images with multiple EBS volumes and as such only the cluster shared volume should be detached at cluster stop time.
Secondly, the user creation fails when one adds users that do not exist at cluster creation time.  This is the case when using the runplugin syntax.  The users.txt file gets in the way. So I added code to create a new users.txt based on the existing one and save the old one with a date time stamp for future comparison/tracking.
