### PR TITLE
added two sentences about the keyname in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,10 @@ For example, the *smallcluster* template would be updated to look like::
     [cluster smallcluster]
     keyname = mykey
 
+It is worth noting that `keyname` needs to be the same name as the .rsa
+file. `keyname` is not just a pointer to the [key mykey] section, but
+is used to determine the AWS key.
+
 Now that the config file has been set up we're ready to start using
 StarCluster. Next we start a cluster named "mycluster" using the default
 cluster template *smallcluster* in the example config::


### PR DESCRIPTION
I got hung up on this part for a good 20 minutes when setting things up, and thought I would suggest two sentences in case it makes the setup easier for others. 

In my first attempt I used 

[key mykey]
key_location = ~/.ssh/myAwsKey.rsa

[cluster smallcluster]
keyname = mykey

I thought that `keyname` just pointed to the [key $keyname] section, and wasn't actually used when connecting to AWS. 

I then changed my config file to

[key myAwskey]
key_location = ~/.ssh/myAwsKey.rsa

[cluster smallcluster]
keyname = myAwskey

and everything worked.
