### PR TITLE
nfs sharing problem when node is added after restart or re-added after removed.

### DIFF
--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -423,7 +423,7 @@ class DefaultClusterSetup(ClusterSetup):
         self._volumes = volumes
         self._setup_hostnames(nodes=[node])
         self._setup_etc_hosts(nodes)
-        self._setup_nfs(nodes=[node], start_server=False)
         self._create_user(node)
+        self._setup_nfs(nodes=[node], start_server=False)
         self._setup_scratch(nodes=[node])
         self._setup_passwordless_ssh(nodes=[node])

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -668,7 +668,7 @@ class Node(object):
         self.stop_exporting_fs_to_nodes(nodes, paths=export_paths)
         log.info("Configuring NFS exports path(s):\n%s" %
                  ' '.join(export_paths))
-        nfs_export_settings = "(async,no_root_squash,no_subtree_check,rw)"
+        #nfs_export_settings = "(async,no_root_squash,no_subtree_check,rw)"
         etc_exports = self.ssh.remote_file('/etc/exports', 'r')
         contents = etc_exports.read()
         etc_exports.close()
@@ -702,6 +702,7 @@ class Node(object):
     def start_nfs_server(self):
         log.info("Starting NFS server on %s" % self.alias)
         self.ssh.execute('/etc/init.d/portmap start', ignore_exit_status=True)
+        #self.ssh.execute('service rpcbind start', ignore_exit_status=True)
         self.ssh.execute('mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs/',
                          ignore_exit_status=True)
         EXPORTSD = '/etc/exports.d'
@@ -728,6 +729,7 @@ class Node(object):
         remote_paths - list of remote paths to mount from server_node
         """
         self.ssh.execute('/etc/init.d/portmap start')
+        #self.ssh.execute('service rpcbind start')
         # TODO: move this fix for xterm somewhere else
         self.ssh.execute('mount -t devpts none /dev/pts',
                          ignore_exit_status=True)


### PR DESCRIPTION
#518 as case, nfs sharing permission error occur when 1."Restarting cluster" or 2."removing nodes and re adding nodes".

At "on_add_node" method in "clustersetup.py"
 "_create_user" before "_setup_nfs" was key to this problem.
