### PR TITLE
support for adding spot nodes during load balancing

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -726,7 +726,7 @@ class SGELoadBalancer(LoadBalancer):
             log.warn("Adding %d nodes at %s" %
                      (need_to_add, str(utils.get_utc_now())))
             try:
-                self._cluster.add_nodes(need_to_add,spot_bid=self.spot_bid)
+                self._cluster.add_nodes(need_to_add, spot_bid=self.spot_bid)
                 self.__last_cluster_mod_time = utils.get_utc_now()
                 log.info("Done adding nodes at %s" %
                          str(self.__last_cluster_mod_time))

--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -438,7 +438,7 @@ class SGELoadBalancer(LoadBalancer):
         self.stats_file = stats_file
         self.plot_stats = plot_stats
         self.plot_output_dir = plot_output_dir
-	self.spot_bit = spot_bid
+        self.spot_bit = spot_bid
         if plot_stats:
             assert self.visualizer is not None
 

--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -418,7 +418,8 @@ class SGELoadBalancer(LoadBalancer):
     def __init__(self, interval=60, max_nodes=None, wait_time=900,
                  add_pi=1, kill_after=45, stab=180, lookback_win=3,
                  min_nodes=None, kill_cluster=False, plot_stats=False,
-                 plot_output_dir=None, dump_stats=False, stats_file=None):
+                 plot_output_dir=None, dump_stats=False, stats_file=None,
+                 spot_bid=None):
         self._cluster = None
         self._keep_polling = True
         self._visualizer = None
@@ -437,6 +438,7 @@ class SGELoadBalancer(LoadBalancer):
         self.stats_file = stats_file
         self.plot_stats = plot_stats
         self.plot_output_dir = plot_output_dir
+	self.spot_bit = spot_bid
         if plot_stats:
             assert self.visualizer is not None
 
@@ -724,7 +726,7 @@ class SGELoadBalancer(LoadBalancer):
             log.warn("Adding %d nodes at %s" %
                      (need_to_add, str(utils.get_utc_now())))
             try:
-                self._cluster.add_nodes(need_to_add)
+                self._cluster.add_nodes(need_to_add,spot_bid=self.spot_bid)
                 self.__last_cluster_mod_time = utils.get_utc_now()
                 log.info("Done adding nodes at %s" %
                          str(self.__last_cluster_mod_time))

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -103,6 +103,10 @@ class CmdLoadBalance(ClusterCompleter):
         parser.add_option("-K", "--kill-cluster", dest="kill_cluster",
                           action="store_true", default=False,
                           help="Terminate the cluster when the queue is empty")
+	parser.add_option("-b", "--bid", dest="spot_bid",
+                          action="callback", type="float", default=None,
+                          callback=self._positive_int,
+                          help="max bid for spot requests, not used by default")
 
     def execute(self, args):
         if not self.cfg.globals.enable_experimental:

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -106,7 +106,7 @@ class CmdLoadBalance(ClusterCompleter):
         parser.add_option("-b", "--bid", dest="spot_bid",
                           action="callback", type="float", default=None,
                           callback=self._positive_int,
-                          help="max bid for spot requests, not used by default")
+                          help="max bid for spot nodes, not used by default")
 
     def execute(self, args):
         if not self.cfg.globals.enable_experimental:

--- a/starcluster/commands/loadbalance.py
+++ b/starcluster/commands/loadbalance.py
@@ -103,7 +103,7 @@ class CmdLoadBalance(ClusterCompleter):
         parser.add_option("-K", "--kill-cluster", dest="kill_cluster",
                           action="store_true", default=False,
                           help="Terminate the cluster when the queue is empty")
-	parser.add_option("-b", "--bid", dest="spot_bid",
+        parser.add_option("-b", "--bid", dest="spot_bid",
                           action="callback", type="float", default=None,
                           callback=self._positive_int,
                           help="max bid for spot requests, not used by default")


### PR DESCRIPTION
This adds the ability to use spot nodes during load balancing on a cluster that has on-demand nodes. A typical use case involves launching an on-demand cluster with a certain number of nodes and using spot bids to add any additional nodes as needed during load balancing.
