### PR TITLE
node: ignore exit status when starting portmap

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -728,7 +728,7 @@ class Node(object):
         server_node - remote server node that is sharing the remote_paths
         remote_paths - list of remote paths to mount from server_node
         """
-        self.ssh.execute('/etc/init.d/portmap start')
+        self.ssh.execute('/etc/init.d/portmap start', ignore_exit_status=True)
         # TODO: move this fix for xterm somewhere else
         self.ssh.execute('mount -t devpts none /dev/pts',
                          ignore_exit_status=True)


### PR DESCRIPTION
This fix continues the work of a23866d, which only hit one of two calls to portmap.
