### PR TITLE
Added new m4 instance types and fixed list of HVM_ONLY_TYPES

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -184,16 +184,20 @@ M3_COMPUTE_TYPES = ['c3.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge',
 M4_COMPUTE_TYPES = ['c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge',
                     'c4.8xlarge']
 
+M4_MEMORY_TYPES = ['m4.large', 'm4.xlarge', 'm4.2xlarge', 'm4.4xlarge',
+                   'm4.10xlarge']
+
 I2_STORAGE_TYPES = ['i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge']
 
 DENSE_STORAGE_TYPES = ['d2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge']
 
 HVM_ONLY_TYPES = (CLUSTER_COMPUTE_TYPES + CLUSTER_GPU_TYPES +
                   CLUSTER_HIMEM_TYPES + I2_STORAGE_TYPES + HIMEM_TYPES +
-                  T2_INSTANCE_TYPES + DENSE_STORAGE_TYPES)
+                  T2_INSTANCE_TYPES + DENSE_STORAGE_TYPES + M4_COMPUTE_TYPES +
+                  M4_MEMORY_TYPES)
 
 HVM_TYPES = (HVM_ONLY_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES +
-             M3_COMPUTE_TYPES + M4_COMPUTE_TYPES)
+             M3_COMPUTE_TYPES)
 
 EBS_ONLY_TYPES = T1_INSTANCE_TYPES + T2_INSTANCE_TYPES
 
@@ -202,8 +206,9 @@ EBS_ONLY_TYPES = T1_INSTANCE_TYPES + T2_INSTANCE_TYPES
 # StarCluster additionally adds cc1.4xlarge to the list - EC2 is slowly
 # migrating folks away from this type in favor of cc2.8xlarge but the type
 # still works for some older accounts.
-PLACEMENT_GROUP_TYPES = (M3_COMPUTE_TYPES + M4_COMPUTE_TYPES + HVM_ONLY_TYPES +
-                         HI_IO_TYPES + HI_STORAGE_TYPES)
+PLACEMENT_GROUP_TYPES = (M3_COMPUTE_TYPES + HVM_ONLY_TYPES + HI_IO_TYPES +
+                         HI_STORAGE_TYPES)
+
 # T2 instances are HVM_ONLY_TYPES however they're not compatible with placement
 # groups so remove them from the list
 for itype in T2_INSTANCE_TYPES:


### PR DESCRIPTION
- AWS recently released M4 instances (https://aws.amazon.com/blogs/aws/the-new-m4-instance-type-bonus-price-reduction-on-m3-c4/) Added them.
- The C4 instances are HVM only instances. Fixed that list as well.
