### PR TITLE
Utility instances upgraded from t1.micro to t2.micro (which is cheape…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# http://travis-ci.org/#!/jtriley/StarCluster
+# http://travis-ci.org/#!/ricrogz/StarCluster
 language: python
 python:
     - 2.6
@@ -7,10 +7,3 @@ install:
     - python setup.py install --quiet
 script:
     - python setup.py test --coverage
-notifications:
-  irc:
-    channels: "irc.freenode.org#starcluster"
-    on_success: change
-    on_failure: change
-    use_notice: true
-    skip_join: true

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,8 @@ StarCluster v0.95.6
 :Team: Software Tools for Academics and Researchers (http://star.mit.edu)
 :Homepage: http://star.mit.edu/cluster
 :License: LGPL
-.. image:: https://secure.travis-ci.org/jtriley/StarCluster.png?branch=develop
-  :target: https://secure.travis-ci.org/jtriley/StarCluster
-.. image:: https://pypip.in/d/StarCluster/badge.png
-  :target: https://crate.io/packages/StarCluster
+.. image:: https://secure.travis-ci.org/ricrogz/StarCluster.png?branch=develop
+  :target: https://secure.travis-ci.org/ricrogz/StarCluster
 
 Description:
 ============

--- a/docs/sphinx/manual/putget.rst
+++ b/docs/sphinx/manual/putget.rst
@@ -23,6 +23,11 @@ To copy files to a different cluster node, use the ``--node`` (``-n``) option::
 
     $ starcluster put mycluster --node node001 /local/path /remote/path
 
+To copy files to multiple cluster nodes, provide comma separated nodes to the
+``--multi`` (``-m``) option::
+
+    $ starcluster put mycluster --multi master,node001 /local/path /remote/path
+
 *********************************
 Copying Data from a Cluster (get)
 *********************************

--- a/starcluster/awsutils.py
+++ b/starcluster/awsutils.py
@@ -477,7 +477,7 @@ class EasyEC2(EasyAWS):
             if instance_type == 'm1.small' and img.architecture == "i386":
                 # Needed for m1.small + 32bit AMI (see gh-329)
                 instance_store = True
-            use_ephemeral = instance_type != 't1.micro'
+            use_ephemeral = instance_type != 't2.micro'
             bdmap = self.create_block_device_map(
                 add_ephemeral_drives=use_ephemeral,
                 num_ephemeral_drives=24,

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -152,6 +152,8 @@ class ClusterManager(managers.Manager):
                                    require_keys=False)
         node = cluster.get_node(node_id)
         key_location = self.cfg.get_key(node.key_name).get('key_location')
+        if node.key_location == "":
+            node.key_location = key_location
         cluster.key_location = key_location
         cluster.keyname = node.key_name
         cluster.validator.validate_keypair()

--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -738,6 +738,7 @@ class Cluster(object):
             for node in self.nodes:
                 if node.is_master():
                     self._master = node
+                    break
             if not self._master:
                 raise exception.MasterDoesNotExist()
         self._master.key_location = self.key_location

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -409,8 +409,8 @@ class DefaultClusterSetup(ClusterSetup):
         master.remove_from_known_hosts(self._user, [node])
 
         user_homedir = os.path.expanduser('~' + self._user)
-        targets = [posixpath.join('/root', '.ssh','known_hosts'),
-                   posixpath.join(user_homedir, '.ssh','known_hosts'),]
+        targets = [posixpath.join('/root', '.ssh', 'known_hosts'),
+                   posixpath.join(user_homedir, '.ssh', 'known_hosts'), ]
 
         for target in targets:
             master.copy_remote_file_to_nodes(target, nodes)

--- a/starcluster/clustersetup.py
+++ b/starcluster/clustersetup.py
@@ -18,6 +18,7 @@
 """
 clustersetup.py
 """
+import os
 import posixpath
 
 from starcluster import utils
@@ -384,17 +385,35 @@ class DefaultClusterSetup(ClusterSetup):
 
     def _remove_from_etc_hosts(self, node):
         nodes = filter(lambda x: x.id != node.id, self.running_nodes)
+        master = None
+
         for n in nodes:
-            n.remove_from_etc_hosts([node])
+            if n.is_master():
+                master = n
+
+        master.remove_from_etc_hosts([node])
+        master.copy_remote_file_to_nodes('/etc/hosts', nodes)
 
     def _remove_nfs_exports(self, node):
         self._master.stop_exporting_fs_to_nodes([node])
 
     def _remove_from_known_hosts(self, node):
         nodes = filter(lambda x: x.id != node.id, self.running_nodes)
+        master = None
+
         for n in nodes:
-            n.remove_from_known_hosts('root', [node])
-            n.remove_from_known_hosts(self._user, [node])
+            if n.is_master():
+                master = n
+
+        master.remove_from_known_hosts('root', [node])
+        master.remove_from_known_hosts(self._user, [node])
+
+        user_homedir = os.path.expanduser('~' + self._user)
+        targets = [posixpath.join('/root', '.ssh','known_hosts'),
+                   posixpath.join(user_homedir, '.ssh','known_hosts'),]
+
+        for target in targets:
+            master.copy_remote_file_to_nodes(target, nodes)
 
     def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
         self._nodes = nodes

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -68,7 +68,7 @@ class CmdPut(ClusterCompleter):
         parser.add_option("-n", "--node", dest="node", default="master",
                           help="Transfer files to NODE (defaults to master)")
         parser.add_option("-m", "--multi", dest="multi", default=None,
-                          help="Transfer files to multiple NODEs (defaults to"
+                          help="Transfer files to multiple NODEs (defaults to "
                           + "master)")
 
     def put(self, node, rpath, lpaths):

--- a/starcluster/commands/put.py
+++ b/starcluster/commands/put.py
@@ -21,6 +21,18 @@ from starcluster import exception
 from completers import ClusterCompleter
 
 
+def list_csv(csv_string):
+    """
+    For parsing comma separated values in --multi e.g. --multi master,node001
+    CommaSeparatedValues -> Nodename Generator
+
+    Removes any empty strings from trailing commas
+    >>> list_csv("master,node001,")
+    ["master", "node001"]
+    """
+    return filter(bool, [name.strip() for name in csv_string.split(',')])
+
+
 class CmdPut(ClusterCompleter):
     """
     put [options] <cluster_tag> [<local_file_or_dir> ...] <remote_destination>
@@ -41,6 +53,10 @@ class CmdPut(ClusterCompleter):
         # Copy a file or dir to a node (node001 in this example)
         $ starcluster put mycluster --node node001 /local/path /remote/path
 
+        # Copy a file or dir to multiple nodes (master and node001 in this
+        # example)
+        $ starcluster put mycluster -m master,node001 /local/path /remote/path
+
 
     This will copy a file or directory to the remote server
     """
@@ -51,6 +67,17 @@ class CmdPut(ClusterCompleter):
                           help="Transfer files as USER ")
         parser.add_option("-n", "--node", dest="node", default="master",
                           help="Transfer files to NODE (defaults to master)")
+        parser.add_option("-m", "--multi", dest="multi", default=None,
+                          help="Transfer files to multiple NODEs (defaults to"
+                          + "master)")
+
+    def put(self, node, rpath, lpaths):
+        if self.opts.user:
+            node.ssh.switch_user(self.opts.user)
+        if len(lpaths) > 1 and not node.ssh.isdir(rpath):
+            msg = "Remote path in %s does not exist: %s" % (node, rpath)
+            raise exception.BaseException(msg)
+        node.ssh.put(lpaths, rpath)
 
     def execute(self, args):
         if len(args) < 3:
@@ -64,10 +91,10 @@ class CmdPut(ClusterCompleter):
                 raise exception.BaseException(
                     "Local file or directory does not exist: %s" % lpath)
         cl = self.cm.get_cluster(ctag, load_receipt=False)
-        node = cl.get_node(self.opts.node)
-        if self.opts.user:
-            node.ssh.switch_user(self.opts.user)
-        if len(lpaths) > 1 and not node.ssh.isdir(rpath):
-            raise exception.BaseException("Remote path does not exist: %s" %
-                                          rpath)
-        node.ssh.put(lpaths, rpath)
+        if self.opts.multi:
+            nodes = [cl.get_node_by_alias(nodename) for nodename in
+                     list_csv(self.opts.multi)]
+        else:
+            nodes = [cl.get_node_by_alias(self.opts.node)]
+        for node in nodes:
+            self.put(node, rpath, lpaths)

--- a/starcluster/config.py
+++ b/starcluster/config.py
@@ -16,6 +16,7 @@
 # along with StarCluster. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import glob
 import urllib
 import StringIO
 import ConfigParser
@@ -228,8 +229,9 @@ class StarClusterConfig(object):
                     include = os.path.expanduser(include)
                     include = os.path.expandvars(include)
                     try:
-                        contents = self._get_cfg_fp(include).read()
-                        mashup.write(contents + '\n')
+                        for inc_file in glob.glob(include):
+                            contents = self._get_cfg_fp(inc_file).read()
+                            mashup.write(contents + '\n')
                     except exception.ConfigNotFound:
                         raise exception.ConfigError("include %s not found" %
                                                     include)

--- a/starcluster/plugins/runbash.py
+++ b/starcluster/plugins/runbash.py
@@ -1,0 +1,56 @@
+# Copyright 2009-2014 Justin Riley
+#
+# This file is part of StarCluster.
+#
+# StarCluster is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# StarCluster is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StarCluster. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+"""
+from starcluster.clustersetup import DefaultClusterSetup
+from starcluster.logger import log
+from starcluster.utils import print_timing
+
+
+class BashRunner(DefaultClusterSetup):
+    """Bash Runner"""
+
+    def __init__(self, bash_file=None):
+        super(BashRunner, self).__init__()
+        self.bash_file = bash_file
+
+    @print_timing("BashRunner")
+    def setup_swap(self, nodes):
+        if not self.bash_file:
+            log.info("No bash file specified!")
+            return
+
+        log.info("Running bash file: %s" % self.bash_file)
+        with open(self.bash_file, 'r') as fp:
+            commands = fp.readlines()
+
+        for command in commands:
+            log.info("$ " + command)
+        cmd = "\n".join(commands)
+        for node in nodes:
+            self.pool.simple_job(node.ssh.execute, (cmd,), jobid=node.alias)
+        self.pool.wait(len(nodes))
+
+    def run(self, nodes, master, user, user_shell, volumes):
+        self.setup_swap(nodes)
+
+    def on_add_node(self, node, nodes, master, user, user_shell, volumes):
+        self.setup_swap([node])
+
+    def on_remove_node(self, node, nodes, master, user, user_shell, volumes):
+        raise NotImplementedError("on_remove_node method not implemented")

--- a/starcluster/volume.py
+++ b/starcluster/volume.py
@@ -43,7 +43,7 @@ class VolumeCreator(cluster.Cluster):
     """
     def __init__(self, ec2_conn, spot_bid=None, keypair=None,
                  key_location=None, host_instance=None, device='/dev/sdz',
-                 image_id=static.BASE_AMI_32, instance_type="t1.micro",
+                 image_id=static.BASE_AMI_32, instance_type="t2.micro",
                  shutdown_instance=False, detach_vol=False,
                  mkfs_cmd='mkfs.ext3 -F', resizefs_cmd='resize2fs', **kwargs):
         self._host_instance = host_instance


### PR DESCRIPTION
Right now, t2.micro instances are allowed under the free tier, and are also cheaper than the older t1.micro instances. It makes more sense to use them as default machine configuration for utilities.
