### PR TITLE
Make loadbalancer account for master instance type

### DIFF
--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -235,10 +235,17 @@ class SGEStats(object):
             return total
         single = 0
         for q in self.queues:
-            if q.startswith('all.q@'):
+            # The 'master' is allowed to have a different instance type
+            # than the others and therefore this should be accounted for.
+            if q == 'all.q@master':
+                master = self.queues[q]['slots']
+            elif q.startswith('all.q@'):
                 single = self.queues.get(q).get('slots')
                 break
-        if (total != (single * len(self.hosts))):
+        else:
+            log.warning('No [non-master] queue found')
+            return -1
+        if total != (master + single * (len(self.hosts) - 1)):
             raise exception.BaseException(
                 "ERROR: Number of slots not consistent across cluster")
         return single

--- a/starcluster/balancers/sge/__init__.py
+++ b/starcluster/balancers/sge/__init__.py
@@ -234,6 +234,7 @@ class SGEStats(object):
         if total == 0:
             return total
         single = 0
+        master = 1
         for q in self.queues:
             # The 'master' is allowed to have a different instance type
             # than the others and therefore this should be accounted for.


### PR DESCRIPTION
The load balancer currently assumes that all nodes in a cluster
(including the master node) are of the same instance type and throws an
exception if this is not so. But the StarCluster config explicitly
allows the master node to be of a different instance type than its
execution hosts. Therefore if a cluster is configured in such a manner
the loadbalancer will fail to run.

This commit makes the loadbalancer take into account that the master
node can be of a different instance type.
