### PR TITLE
display exceptions in threadpool, and look for 'mpich', not 'mpich2'

### DIFF
--- a/starcluster/plugins/mpich2.py
+++ b/starcluster/plugins/mpich2.py
@@ -33,12 +33,12 @@ class MPICH2Setup(clustersetup.DefaultClusterSetup):
         mpirun_choices = node.ssh.execute("update-alternatives --list mpirun")
         mpipath = None
         for choice in mpi_choices:
-            if 'mpich2' in choice:
+            if 'mpich' in choice:
                 mpipath = choice
                 break
         mpirunpath = None
         for choice in mpirun_choices:
-            if 'mpich2' in choice:
+            if 'mpich' in choice:
                 mpirunpath = choice
                 break
         node.ssh.execute("update-alternatives --set mpi %s" % mpipath)

--- a/starcluster/threadpool.py
+++ b/starcluster/threadpool.py
@@ -173,6 +173,7 @@ class ThreadPool(workerpool.WorkerPool):
         exc_queue = self._exception_queue
         if exc_queue.qsize() > 0:
             excs = [exc_queue.get() for i in range(exc_queue.qsize())]
+            print '\n'.join(excs)
             raise exception.ThreadPoolException(
                 "An error occurred in ThreadPool", excs)
         if return_results:


### PR DESCRIPTION
Two changes:

1) The mpich2 plugin searches for 'mpich2' in the output of 'update-alternatives --list mpirun' to find the location of the mpich2 path, but in Ubuntu 15.04, the command name is mpirun.mpich to run mpich2, so the search fails and causes an error. I changed the search for the more general 'mpich'

2) To facilitate debugging of plugins, prints the exceptions that arise in running a threadpool before raising a threadpool exception (the latter is not verbose enough in its output). I find this useful for seeing exactly what the commandline was in a node.ssh.execute command that failed during the run of a plugin. 
