### PR TITLE
Base AMIs defaults in correct zone for creating/resizing volumes.

### DIFF
--- a/starcluster/commands/createvolume.py
+++ b/starcluster/commands/createvolume.py
@@ -16,6 +16,7 @@
 # along with StarCluster. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 
 from starcluster import node
 from starcluster import volume
@@ -141,6 +142,9 @@ class CmdCreateVolume(CmdBase):
         kwargs = self.specified_options_dict
         kwargs.update(dict(keypair=keypair, key_location=key_location,
                            host_instance=host_instance))
+        if 'image_id' not in kwargs.keys():
+            zone_short = re.match(".+-.+-[1-9]+", zone).group()
+            kwargs['image_id'] = static.BASE_AMI_64[zone_short]
         vc = volume.VolumeCreator(self.ec2, **kwargs)
         if host_instance:
             vc._validate_host_instance(host_instance, zone)

--- a/starcluster/commands/resizevolume.py
+++ b/starcluster/commands/resizevolume.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with StarCluster. If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 from starcluster import node
 from starcluster import volume
 from starcluster import static
@@ -96,6 +98,9 @@ class CmdResizeVolume(CmdCreateVolume):
         kwargs = self.specified_options_dict
         kwargs.update(dict(keypair=keypair, key_location=key_location,
                            host_instance=host_instance))
+        if 'image_id' not in kwargs.keys():
+            zone_short = re.match(".+-.+-[1-9]+", zone).group()
+            kwargs['image_id'] = static.BASE_AMI_64[zone_short]
         vc = volume.VolumeCreator(self.ec2, **kwargs)
         if host_instance:
             vc._validate_host_instance(host_instance, zone)

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -81,9 +81,13 @@ AWS_DEBUG_FILE = os.path.join(STARCLUSTER_LOG_DIR, 'aws-debug.log')
 CRASH_FILE = os.path.join(STARCLUSTER_LOG_DIR, 'crash-report-%d.txt' % PID)
 
 # StarCluster BASE AMIs (us-east-1)
-BASE_AMI_32 = "ami-9bf9c9f2"
-BASE_AMI_64 = "ami-3393a45a"
-BASE_AMI_HVM = "ami-6b211202"
+BASE_AMI_32 = {'us-east-1': "ami-9bf9c9f2", 'us-west-1': "ami-52112317",
+               'us-west-2': "ami-b2badb82"}
+BASE_AMI_64 = {'us-east-1': "ami-3393a45a", 'us-west-1': "ami-56172513",
+               'us-west-2': "ami-04bedf34"}
+BASE_AMI_HVM = {'us-east-1': "ami-6b211202", 'us-west-1': "ami-06172543",
+                'us-west-2': "ami-80bedfb0"}
+
 
 SECURITY_GROUP_PREFIX = "@sc-"
 SECURITY_GROUP_TEMPLATE = SECURITY_GROUP_PREFIX + "%s"

--- a/starcluster/templates/config.py
+++ b/starcluster/templates/config.py
@@ -349,9 +349,9 @@ NODE_INSTANCE_TYPE = m1.small
 # [plugin xvfb]
 # SETUP_CLASS = starcluster.plugins.xvfb.XvfbSetup
 """ % {
-    'x86_ami': static.BASE_AMI_32,
-    'x86_64_ami': static.BASE_AMI_64,
-    'hvm_ami': static.BASE_AMI_HVM,
+    'x86_ami': static.BASE_AMI_32['us-east-1'],
+    'x86_64_ami': static.BASE_AMI_64['us-east-1'],
+    'hvm_ami': static.BASE_AMI_HVM['us-east-1'],
     'instance_types': ', '.join(static.INSTANCE_TYPES.keys()),
     'shells': ', '.join(static.AVAILABLE_SHELLS.keys()),
 }

--- a/starcluster/volume.py
+++ b/starcluster/volume.py
@@ -58,6 +58,7 @@ class VolumeCreator(cluster.Cluster):
         self._mkfs_cmd = mkfs_cmd
         self._resizefs_cmd = resizefs_cmd
         self._alias_tmpl = "volhost-%s"
+        self._snapshot = None
         super(VolumeCreator, self).__init__(
             ec2_conn=ec2_conn, spot_bid=spot_bid, keyname=keypair,
             key_location=key_location, cluster_tag=static.VOLUME_GROUP_NAME,

--- a/starcluster/volume.py
+++ b/starcluster/volume.py
@@ -43,15 +43,16 @@ class VolumeCreator(cluster.Cluster):
     """
     def __init__(self, ec2_conn, spot_bid=None, keypair=None,
                  key_location=None, host_instance=None, device='/dev/sdz',
-                 image_id=static.BASE_AMI_32, instance_type="t1.micro",
-                 shutdown_instance=False, detach_vol=False,
-                 mkfs_cmd='mkfs.ext3 -F', resizefs_cmd='resize2fs', **kwargs):
+                 image_id=static.BASE_AMI_32['us-east-1'],
+                 instance_type="t1.micro", shutdown_instance=False,
+                 detach_vol=False, mkfs_cmd='mkfs.ext3 -F',
+                 resizefs_cmd='resize2fs', **kwargs):
         self._host_instance = host_instance
         self._instance = None
         self._volume = None
         self._aws_block_device = device or '/dev/sdz'
         self._real_device = None
-        self._image_id = image_id or static.BASE_AMI_32
+        self._image_id = image_id or static.BASE_AMI_32['us-east-1']
         self._instance_type = instance_type or 'm1.small'
         self._shutdown = shutdown_instance
         self._detach_vol = detach_vol
@@ -207,7 +208,7 @@ class VolumeCreator(cluster.Cluster):
         try:
             self.validate(size, zone, device)
             return True
-        except exception.BaseException, e:
+        except exception.BaseException as e:
             log.error(e.msg)
             return False
 


### PR DESCRIPTION
This addresses Issue #554 and provides default AMIs in the correct zone when creating and resizing volumes by implementing the `static.BASE_AMI_*` variables as dictionaries.
