### PR TITLE
Support for AWS Security Groups

### DIFF
--- a/docs/sphinx/manual/configuration.rst
+++ b/docs/sphinx/manual/configuration.rst
@@ -574,18 +574,33 @@ will be NFS-shared to the rest of the cluster nodes.
 
 .. _config_permissions:
 
-Amazon Security Group Permissions
----------------------------------
+Amazon Security Groups
+----------------------
 When starting a cluster each node is added to a common security group. This
 security group is created by StarCluster and has a name of the form
 ``@sc-<cluster_tag>`` where ``<cluster_tag>`` is the name you provided to the
 **start** command.
 
-By default, StarCluster adds a permission to this security group that allows
-access to port 22 (ssh) from all IP addresses. This is needed so that
-StarCluster can connect to the instances and configure them properly. If you
-want to specify additional security group permissions to be set after starting
-your cluster you can do so in the config by creating one or more
+You can specify any number of security groups to which the cluster nodes will
+be added. To do this, specify a **STATIC_SECURITY_GROUPS** setting in a
+**[cluster]** section and set the value to be a comma-delimited list of
+security group names. The specified security groups must exist and will not
+be automatically created.
+
+.. code-block:: ini
+
+    [cluster smallcluster]
+    #...
+    STATIC_SECURITY_GROUPS = default, services
+    #...
+
+Amazon Security Group Permissions
+---------------------------------
+By default, StarCluster adds a permission to the ``@sc-<cluster_tag>`` security
+group that allows access to port 22 (ssh) from all IP addresses. This is needed
+so that StarCluster can connect to the instances and configure them properly.
+If you want to specify additional security group permissions to be set after
+starting your cluster you can do so in the config by creating one or more
 **[permission]** sections. These sections can then be specified in one or more
 cluster templates. Here's an example that opens port 80 (web server) to the
 world for the ``smallcluster`` template:

--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -215,6 +215,11 @@ class Node(object):
         return filter(lambda x: x.name.startswith(sg_prefix), self.groups)
 
     @property
+    def static_groups(self):
+        sg_prefix = static.SECURITY_GROUP_PREFIX
+        return filter(lambda x: not x.name.startswith(sg_prefix), self.groups)
+
+    @property
     def parent_cluster(self):
         try:
             return self.cluster_groups[0]

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -308,6 +308,7 @@ CLUSTER_SETTINGS = {
     'userdata_scripts': (list, False, [], None, __expand_all_in_list),
     'disable_queue': (bool, False, False, None, None),
     'force_spot_master': (bool, False, False, None, None),
+    'static_security_groups': (list, False, [], None, None),
     'disable_cloudinit': (bool, False, False, None, None),
     'dns_prefix': (bool, False, False, None, None),
 }

--- a/starcluster/templates/config.py
+++ b/starcluster/templates/config.py
@@ -146,6 +146,9 @@ NODE_INSTANCE_TYPE = m1.small
 # list of permissions (or firewall rules) to apply to the cluster's security
 # group (OPTIONAL).
 #PERMISSIONS = ssh, http
+# Add nodes to these pre-defined security groups in addition to the
+# starcluster security group. (optional) 
+#STATIC_SECURITY_GROUPS = default, services
 # Uncomment to always create a spot cluster when creating a new cluster from
 # this template. The following example will place a $0.50 bid for each spot
 # request.


### PR DESCRIPTION
### AWS security groups support merged to current head of develop branch
#### Background:

We (@motologic) forked StarCluster to allow us to configure our nodes with existing AWS security groups via a patch based on work by @dmachi and included in PR [#74](https://github.com/jtriley/StarCluster/pull/74).

This was not accepted so a second attempt was made by @mikepfirrmann with further changes and submitted as PR [#247](https://github.com/jtriley/StarCluster/pull/247).

This was not accepted either but, from the PR dialog, it seems issues were reported by a [ci-travis build due to incorrect line lengths](https://travis-ci.org/jtriley/StarCluster/jobs/33215583).

I've merged the changes against head of develop with cosmetic changes to shorten the lines. We hope you consider this PR merge.
