### PR TITLE
Updated AWS Instance Types

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -197,13 +197,16 @@ M4_COMPUTE_TYPES = ['c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge',
                     'c4.8xlarge', 'm4.large', 'm4.xlarge', 'm4.2xlarge',
                     'm4.4xlarge', 'm4.10xlarge', 'm4.16xlarge']
 
+GPU_COMPUTE_TYPES = ['p2.xlarge','p2.8xlarge','p2.16xlarge',
+                     'g2.2xlarge','g2.8xlarge']
+
 I2_STORAGE_TYPES = ['i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge']
 
 DENSE_STORAGE_TYPES = ['d2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge']
 
 HVM_ONLY_TYPES = (CLUSTER_COMPUTE_TYPES + CLUSTER_GPU_TYPES +
                   CLUSTER_HIMEM_TYPES + I2_STORAGE_TYPES + HIMEM_TYPES +
-                  T2_INSTANCE_TYPES + DENSE_STORAGE_TYPES)
+                  T2_INSTANCE_TYPES + DENSE_STORAGE_TYPES + GPU_COMPUTE_TYPES)
 
 HVM_TYPES = (HVM_ONLY_TYPES + HI_IO_TYPES + HI_STORAGE_TYPES + SEC_GEN_TYPES +
              M3_COMPUTE_TYPES + M4_COMPUTE_TYPES)

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -163,7 +163,12 @@ INSTANCE_TYPES = {
     'd2.xlarge': ['x86_64'],
     'd2.2xlarge': ['x86_64'],
     'd2.4xlarge': ['x86_64'],
-    'd2.8xlarge': ['x86_64']
+    'd2.8xlarge': ['x86_64'],
+    'p2.xlarge': ['x86_64'],
+    'p2.8xlarge': ['x86_64'],
+    'p2.16xlarge': ['x86_64'],
+    'g2.2xlarge': ['x86_64'],
+    'g2.8xlarge': ['x86_64']
 }
 
 T1_INSTANCE_TYPES = ['t1.micro']


### PR DESCRIPTION
I added the new P2 and G2 AWS GPU instances to the list of available instances and added them to the `HVM_ONLY_TYPES` list. 